### PR TITLE
refactor: use an array of tests to create columns

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,24 +1,17 @@
-import { readdirSync, writeFileSync } from "fs";
+import { readdirSync } from "fs";
 import { resolve } from "path";
 import { ping } from "./utils/client";
 import { generateMarkdown } from "./utils/markdown";
 import execa from "execa";
 import debug from "debug";
 import { Writable } from "stream";
+import { runJest, TestResult, TESTS } from "./testRunner";
 
 const dockerDebug = debug("docker");
 const dockerDebugStream = () =>
   new Writable({
     write(chunk, encoding, next) {
       dockerDebug(chunk.toString());
-      next();
-    },
-  });
-const jestDebug = debug("test");
-const jestDebugStream = () =>
-  new Writable({
-    write(chunk, encoding, next) {
-      jestDebug(chunk.toString());
       next();
     },
   });
@@ -30,22 +23,6 @@ function getFolderNamesFromPath(path: string) {
     .filter((dirent) => dirent.isDirectory())
     .map((dirent) => dirent.name);
 }
-
-class KeySupport {
-  singleField: boolean = false;
-  multipleFields: boolean = false;
-  composite: boolean = false;
-}
-
-export class TestResult {
-  startedSuccessfully: boolean = false;
-  serviceSdl: boolean = false;
-  keySupport: KeySupport = new KeySupport();
-  requiresSupport: boolean = false;
-  providesSupport: boolean = false;
-  ftv1Support: boolean = false;
-}
-let results = new Map<string, TestResult>();
 
 async function runDockerCompose(libraryName: string, librariesPath: string) {
   console.log("Starting containers...");
@@ -64,9 +41,7 @@ async function runDockerCompose(libraryName: string, librariesPath: string) {
 
   await proc;
 
-  if (proc.exitCode === 0) {
-    results.get(libraryName).startedSuccessfully = true;
-  } else {
+  if (proc.exitCode !== 0) {
     throw new Error("docker-compose did not start successfully");
   }
 
@@ -74,54 +49,6 @@ async function runDockerCompose(libraryName: string, librariesPath: string) {
     console.log("Stopping containers...");
     await execa("docker-compose", ["down", "--remove-orphans"]);
   };
-}
-
-async function runJest(libraryName: string): Promise<JestJSONOutput> {
-  const jestBin = require.resolve("jest/bin/jest");
-  const proc = execa(jestBin, ["src", "--ci", "--json"], { reject: false });
-
-  proc.stdout.pipe(jestDebugStream());
-  proc.stderr.pipe(jestDebugStream());
-
-  const { stdout, stderr } = await proc;
-
-  if (proc.exitCode > 1) {
-    throw new Error("jest failed to run");
-  }
-
-  const results = JSON.parse(stdout) as JestJSONOutput;
-
-  if (results.numFailedTests > 0) {
-    writeFileSync(`tmp/${libraryName}-testfailures.txt`, stderr, "utf-8");
-  }
-
-  return results;
-}
-
-interface JestJSONOutput {
-  numFailedTestSuites: number;
-  numFailedTests: number;
-  numPassedTestSuites: number;
-  numPassedTests: number;
-  numPendingTestSuites: number;
-  numPendingTests: number;
-  numRuntimeErrorTestSuites: number;
-  numTodoTests: number;
-  numTotalTestSuites: number;
-  numTotalTests: number;
-  success: boolean;
-  testResults: {
-    name: string;
-    status: "failed" | "passed";
-    summary: string;
-    message: string;
-    assertionResults: {
-      failureMessages: string[];
-      fullName: string;
-      status: "failed" | "passed";
-      title: string;
-    }[];
-  }[];
 }
 
 (async () => {
@@ -133,6 +60,8 @@ interface JestJSONOutput {
   const implementationFolders = getFolderNamesFromPath(librariesPath);
   const libraryNames = libraries ? libraries.split(",") : implementationFolders;
 
+  const results = new Map<string, TestResult>();
+
   for (const libraryName of libraryNames) {
     if (libraryName == "_template_") continue;
     if (!implementationFolders.includes(libraryName)) {
@@ -142,7 +71,8 @@ interface JestJSONOutput {
       continue;
     }
 
-    results.set(libraryName, new TestResult());
+    const result: TestResult = { name: libraryName, started: false, tests: {} };
+    results.set(libraryName, result);
 
     const dockerComposeDown = await runDockerCompose(
       libraryName,
@@ -155,29 +85,17 @@ interface JestJSONOutput {
       if (startupSuccess) {
         console.log(`Library ${libraryName} started successfully`);
 
-        const libraryResults = results.get(libraryName);
-        libraryResults.startedSuccessfully = true;
+        result.started = true;
 
-        const jestOutput = await runJest(libraryName);
-        const assertions = jestOutput.testResults.flatMap(
-          (x) => x.assertionResults
-        );
+        const { assertionPassed } = await runJest(libraryName);
 
-        const assertionPassed = (name: string) =>
-          assertions.find((a) => a.fullName === name)?.status === "passed";
-
-        libraryResults.serviceSdl = assertionPassed("introspection");
-        libraryResults.keySupport.singleField = assertionPassed("@key single");
-        libraryResults.keySupport.multipleFields =
-          assertionPassed("@key multiple");
-        libraryResults.keySupport.composite = assertionPassed("@key composite");
-        libraryResults.requiresSupport = assertionPassed("@requires");
-        libraryResults.providesSupport = assertionPassed("@provides");
-        libraryResults.ftv1Support = assertionPassed("ftv1");
+        for (const { assertion } of TESTS) {
+          result.tests[assertion] = { success: assertionPassed(assertion) };
+        }
 
         console.log(`Library ${libraryName} complete!`);
       } else {
-        results.get(libraryName).startedSuccessfully = false;
+        result.started = false;
         console.log(`Library ${libraryName} was not started successfully`);
       }
     } catch (err) {

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -1,0 +1,97 @@
+import { writeFileSync } from "fs";
+import execa from "execa";
+import debug from "debug";
+import { Writable } from "stream";
+
+const jestDebug = debug("test");
+const jestDebugStream = () =>
+  new Writable({
+    write(chunk, encoding, next) {
+      jestDebug(chunk.toString());
+      next();
+    },
+  });
+
+export const TESTS = [
+  { assertion: "introspection", column: "_service" },
+  { assertion: "@key single", column: "@key (single)" },
+  { assertion: "@key multiple", column: "@key (multi)" },
+  { assertion: "@key composite", column: "@key (composite)" },
+  { assertion: "@requires", column: "@requires" },
+  { assertion: "@provides", column: "@provides" },
+  { assertion: "ftv1", column: "@ftv1" },
+];
+
+export async function runJest(libraryName: string): Promise<JestResults> {
+  const jestBin = require.resolve("jest/bin/jest");
+  const proc = execa(jestBin, ["src", "--ci", "--json"], { reject: false });
+
+  proc.stdout.pipe(jestDebugStream());
+  proc.stderr.pipe(jestDebugStream());
+
+  const { stdout, stderr } = await proc;
+
+  if (proc.exitCode > 1) {
+    throw new Error("jest failed to run");
+  }
+
+  const results = JSON.parse(stdout) as JestJSONOutput;
+
+  if (results.numFailedTests > 0) {
+    writeFileSync(`tmp/${libraryName}-testfailures.txt`, stderr, "utf-8");
+  }
+
+  const assertions = results.testResults.flatMap((x) => x.assertionResults);
+  const assertionPassed = (name: string) =>
+    assertions.find((a) => a.fullName === name)?.status === "passed";
+
+  return {
+    rawResults: results,
+    assertions,
+    assertionPassed,
+  };
+}
+
+export interface TestResult {
+  name: string;
+  started: boolean;
+  tests: {
+    [name: string]: {
+      success: boolean;
+    };
+  };
+}
+
+export interface JestAssertionResult {
+  failureMessages: string[];
+  fullName: string;
+  status: "failed" | "passed";
+  title: string;
+}
+
+export interface JestJSONOutput {
+  numFailedTestSuites: number;
+  numFailedTests: number;
+  numPassedTestSuites: number;
+  numPassedTests: number;
+  numPendingTestSuites: number;
+  numPendingTests: number;
+  numRuntimeErrorTestSuites: number;
+  numTodoTests: number;
+  numTotalTestSuites: number;
+  numTotalTests: number;
+  success: boolean;
+  testResults: {
+    name: string;
+    status: "failed" | "passed";
+    summary: string;
+    message: string;
+    assertionResults: JestAssertionResult[];
+  }[];
+}
+
+export interface JestResults {
+  rawResults: JestJSONOutput;
+  assertions: JestAssertionResult[];
+  assertionPassed: (name: string) => boolean;
+}

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,59 +1,59 @@
-import { TestResult } from "..";
 import { writeFileSync } from "fs";
 import { resolve } from "path";
+import { TestResult, TESTS } from "../testRunner";
 
 export function generateMarkdown(results: Map<string, TestResult>) {
   const markdownFile = new MarkdownFile(
     "Subgraph libraries that support Apollo Federation",
     "Supported subgraph libraries"
   );
-  results.forEach((result, framework) =>
-    markdownFile.addFrameworkResultToTable(framework, result)
-  );
+
+  for (const [_, result] of results) {
+    markdownFile.addFrameworkResultToTable(result);
+  }
 
   writeFileSync(
     resolve(__dirname, "..", "..", "results.md"),
-    markdownFile.content,
-    { encoding: "utf-8" }
+    markdownFile.toString(),
+    "utf-8"
   );
 }
 
 class MarkdownFile {
-  content: string = "";
+  private content: string[] = [];
 
   constructor(title: string, sidebarTitle: string) {
-    this.content = `---\ntitle: ${title}\nsidebar_title: ${sidebarTitle}\n---\n`;
-    this.content += `\nThe following open-source GraphQL server libraries provide support for Apollo Federation and are included in our test suite.\n\n`;
+    this.content.push(
+      `---\ntitle: ${title}\nsidebar_title: ${sidebarTitle}\n---\n`
+    );
+    this.content.push(
+      `\nThe following open-source GraphQL server libraries provide support for Apollo Federation and are included in our test suite.\n\n`
+    );
     this.addTable();
   }
 
   addTable() {
-    this.content += `| Framework | _service | @key (single) | @key (multi) | @key (composite) | @requires | @provides | ftv1 |\n`;
-    this.content += `| --- | --- | --- | --- | --- | --- | --- | --- |\n`;
-  }
-  addFrameworkResultToTable(framework: string, result: TestResult) {
-    this.content += `| ${framework} `;
-    this.content += result.serviceSdl ? this.check() : this.cross();
-    this.content += result.keySupport.singleField ? this.check() : this.cross();
-    this.content += result.keySupport.multipleFields
-      ? this.check()
-      : this.cross();
-    this.content += result.keySupport.composite ? this.check() : this.cross();
-    this.content += result.requiresSupport ? this.check() : this.cross();
-    this.content += result.providesSupport ? this.check() : this.cross();
-    this.content += result.ftv1Support
-      ? `${this.check()} |`
-      : `${this.cross()} |`;
-    this.content += "\n";
-  }
-  addText(text: string) {
-    this.content += `${text}\n`;
+    const columns = ["Framework", ...TESTS.map((t) => t.column)];
+    this.content.push(`| ${columns.join(" | ")} |`);
+    this.content.push(
+      `| ${new Array(columns.length)
+        .fill(1)
+        .map(() => "---")
+        .join(" | ")} |`
+    );
   }
 
-  private check(): string {
-    return "| ✔️ ";
+  addFrameworkResultToTable(result: TestResult) {
+    const rows = [
+      result.name,
+      ...TESTS.map((t) => {
+        return result.tests[t.assertion]?.success ? "✔️" : "❌";
+      }),
+    ];
+    this.content.push(`| ${rows.join(" | ")} |`);
   }
-  private cross(): string {
-    return "| ❌ ";
+
+  toString() {
+    return this.content.join("\n");
   }
 }


### PR DESCRIPTION
This change refactors the test runner to iterate over an array of tests to construct the results. This will hopefully make it easier to A. add new tests in the future and B. merge test metadata from a yaml file or something