### PR TITLE
Reduce number of string copies in async-graphql implementation

### DIFF
--- a/implementations/async-graphql/product-graphql/src/graphql.rs
+++ b/implementations/async-graphql/product-graphql/src/graphql.rs
@@ -12,25 +12,25 @@ pub struct Query;
 
 #[Object(extends)]
 impl Query {
-    pub async fn product(&self, ctx: &Context<'_>, id: ID) -> Option<Product> {
+    pub async fn product<'a>(&self, ctx: &Context<'a>, id: ID) -> Option<Product<'a>> {
       let repo = ctx.data::<ProductRepository>().unwrap();
       repo.get(id)
     }
 
     #[graphql(entity)]
-    async fn find_product_by_id(&self, ctx: &Context<'_>, id: ID) -> Option<Product> {
+    async fn find_product_by_id<'a>(&self, ctx: &Context<'a>, id: ID) -> Option<Product<'a>> {
       let repo = ctx.data::<ProductRepository>().unwrap();
       repo.get(id)
     }
 
     #[graphql(entity)]
-    async fn find_product_by_sku_and_package(&self, ctx: &Context<'_>, sku: String, package: String) -> Option<Product> {
+    async fn find_product_by_sku_and_package<'a>(&self, ctx: &Context<'a>, sku: String, package: String) -> Option<Product<'a>> {
       let repo = ctx.data::<ProductRepository>().unwrap();
       repo.get_with_sku_and_package(sku, package)
     }
 
     #[graphql(entity)]
-    async fn find_product_by_sku_and_variation_id(&self, ctx: &Context<'_>, sku: String, variation: VariationIdKey) -> Option<Product> {
+    async fn find_product_by_sku_and_variation_id<'a>(&self, ctx: &Context<'a>, sku: String, variation: VariationIdKey) -> Option<Product<'a>> {
       let repo = ctx.data::<ProductRepository>().unwrap();
       repo.get_with_sku_and_variation_id(sku, variation.id)
     }
@@ -38,29 +38,29 @@ impl Query {
 }
 
 #[derive(Clone)]
-pub struct Product {
+pub struct Product<'a> {
     pub id: ID,
-    pub sku: Option<String>,
-    pub package: Option<String>,
+    pub sku: Option<&'a str>,
+    pub package: Option<&'a str>,
     pub variation: Option<ProductVariation>,
 }
 
 #[Object]
-impl Product {
+impl Product<'_> {
     pub async fn id(&self) -> &ID {
       &self.id
     }
-    pub async fn sku(&self) -> &Option<String> {
+    pub async fn sku(&self) -> &Option<&str> {
       &self.sku
     }
-    pub async fn package(&self) -> &Option<String> {
+    pub async fn package(&self) -> &Option<&str> {
       &self.package
     }
     pub async fn variation(&self) -> &Option<ProductVariation> {
       &self.variation
     }
-    pub async fn dimensions(&self) -> Option<ProductDimension> {
-      Some(ProductDimension { size: Some("1".to_string()), weight: Some(1f32) })
+    pub async fn dimensions(&self) -> Option<ProductDimension<'_>> {
+      Some(ProductDimension { size: Some("1"), weight: Some(1f32) })
     }
 
     #[graphql(provides="totalProductsCreated")]
@@ -75,8 +75,8 @@ pub struct ProductVariation {
 }
 
 #[derive(SimpleObject)]
-pub struct ProductDimension {
-	size: Option<String>,
+pub struct ProductDimension<'a> {
+	size: Option<&'a str>,
 	weight: Option<f32>,
 }
 

--- a/implementations/async-graphql/product-graphql/src/products.rs
+++ b/implementations/async-graphql/product-graphql/src/products.rs
@@ -1,30 +1,30 @@
 use async_graphql::ID;
 use crate::graphql::{Product, ProductVariation};
 
-pub struct ProductRepository {
-    pub products: Vec<Product>,
+pub struct ProductRepository<'a> {
+    pub products: Vec<Product<'a>>,
 }
 
-impl Default for ProductRepository {
+impl Default for ProductRepository<'_> {
     fn default() -> Self {
         let mut products = Vec::new();
         products.push(Product {
             id: "apollo-federation".into(),
-            sku: Some("federation".to_string()),
-            package: Some("@apollo/federation".to_string()),
+            sku: Some("federation"),
+            package: Some("@apollo/federation"),
             variation: Some(ProductVariation { id: "OSS".into() }),
         });
         products.push(Product {
             id: "apollo-studio".into(),
-            sku: Some("sku".to_string()),
-            package: Some("".to_string()),
+            sku: Some("sku"),
+            package: Some(""),
             variation: Some(ProductVariation { id: "platform".into() }),
         });
         ProductRepository { products }
     }
 }
 
-impl ProductRepository {
+impl ProductRepository<'_> {
 	pub fn get(&self, id: ID) -> Option<Product> {
 		(&self.products).into_iter()
 			.find(|p| p.id == id)
@@ -33,14 +33,14 @@ impl ProductRepository {
 
 	pub fn get_with_sku_and_package(&self, sku: String, package: String) -> Option<Product> {
 		(&self.products).into_iter()
-			.find(|p| p.sku == Some(sku.clone()) && p.package == Some(package.clone()))
+			.find(|p| p.sku == Some(&sku) && p.package == Some(&package))
 			.and_then(|p| Some(p.clone()))
 	}
 
 	pub fn get_with_sku_and_variation_id(&self, sku: String, variation_id: ID) -> Option<Product> {
 		(&self.products).into_iter()
 			.find(|p| {
-                let matches_sku = p.sku == Some(sku.clone());
+                let matches_sku = p.sku == Some(&sku);
                 let matches_variation_id = match &p.variation {
                     Some(variation) => variation.id == variation_id,
                     None => false,


### PR DESCRIPTION
- Same results.md output when running locally
- Should reduce allocations within server
- Less about improvements on implementation, but more on better perf if using this implementation as a base or reference