### PR TITLE
local GitHub action tests via `act`

### DIFF
--- a/.github/workflows/local.yaml
+++ b/.github/workflows/local.yaml
@@ -1,0 +1,70 @@
+name: Local
+
+on:
+  workflow_dispatch:
+    inputs:
+      implementation:
+        description: 'implementation name to test, empty for all'
+        required: false
+        default: "apollo-server"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      IMPLEMENTATION: ${{ github.event.inputs.implementation }}
+    steps:
+      - uses: actions/checkout@v2
+      -
+        name: update docker-compose
+        run: |
+          which docker-compose && exit 0 || true
+          echo ---------------------------------------------------------------
+          echo docker-compose - installing ...
+          echo ---------------------------------------------------------------
+          BIN_DIR=$HOME/.docker-compose/bin
+          FILE=$BIN_DIR/docker-compose
+          mkdir -p $BIN_DIR
+          set -x
+          curl -L --fail https://github.com/docker/compose/releases/download/1.29.2/docker-compose-`uname -s`-`uname -m` -o $FILE
+          chmod +x $FILE
+          echo "downloaded $($FILE --version)"
+          echo "$BIN_DIR" >> ${GITHUB_PATH}
+          set +x
+          echo ---------------------------------------------------------------
+      - name: setup node
+        uses: actions/setup-node@master
+        with:
+          node-version: 14.x
+      -
+        name: dump info
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          echo ---------------------------------------------------------------
+          echo "$GITHUB_CONTEXT"
+          echo ---------------------------------------------------------------
+          echo "implementation: ${IMPLEMENTATION}"
+          echo ---------------------------------------------------------------
+          ( set -x; which docker )
+          echo "$(docker --version)"
+          echo ---------------------------------------------------------------
+          ( set -x; which docker-compose )
+          echo "$(docker-compose --version)"
+          echo ---------------------------------------------------------------
+          ( set -x; which node )
+          echo "$(node --version)"
+          echo ---------------------------------------------------------------
+          ( set -x; which npm )
+          echo "$(npm --version)"
+          echo ---------------------------------------------------------------
+      - run: npm install
+      - run: npm run setup
+      - run: npm run test ${IMPLEMENTATION}
+        env:
+          DEBUG: docker,test
+      - name: Done
+        run: |
+          echo ---------------------------------------------------------------
+          echo "implementation: ${IMPLEMENTATION}" complete
+          echo ---------------------------------------------------------------

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ secrets.yml
 
 tmp/*
 !tmp/.keep
+
+act-test.run

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,74 @@
+.PHONY: default
+default: test
+
+ubuntu-latest=ubuntu-latest=catthehacker/ubuntu:act-latest
+
+.PHONY: test
+test:
+	sed 's/RUN//g' act-test.event > act-test.run
+	act -P $(ubuntu-latest) -W .github/workflows/local.yaml --eventpath act-test.run --detect-event; rm act-test.run
+
+.PHONY: test-absinthe-federation
+test-absinthe-federation:
+	sed 's/RUN/absinthe-federation/g' act-test.event > act-test.run
+	act -P $(ubuntu-latest) -W .github/workflows/local.yaml --eventpath act-test.run --detect-event; rm act-test.run
+
+.PHONY: test-apollo-server
+test-apollo-server:
+	sed 's/RUN/apollo-server/g' act-test.event > act-test.run
+	act -P $(ubuntu-latest) -W .github/workflows/local.yaml --eventpath act-test.run --detect-event; rm act-test.run
+
+.PHONY: test-appsync
+test-appsync:
+	sed 's/RUN/appsync/g' act-test.event > act-test.run
+	act -P $(ubuntu-latest) -W .github/workflows/local.yaml --eventpath act-test.run --detect-event; rm act-test.run
+
+.PHONY: test-ariadne
+test-ariadne:
+	sed 's/RUN/ariadne/g' act-test.event > act-test.run
+	act -P $(ubuntu-latest) -W .github/workflows/local.yaml --eventpath act-test.run --detect-event; rm act-test.run
+
+.PHONY: test-async-graphql
+test-async-graphql:
+	sed 's/RUN/async-graphql/g' act-test.event > act-test.run
+	act -P $(ubuntu-latest) -W .github/workflows/local.yaml --eventpath act-test.run --detect-event; rm act-test.run
+
+.PHONY: test-caliban
+test-caliban:
+	sed 's/RUN/caliban/g' act-test.event > act-test.run
+	act -P $(ubuntu-latest) -W .github/workflows/local.yaml --eventpath act-test.run --detect-event; rm act-test.run
+
+.PHONY: test-dgs
+test-dgs:
+	sed 's/RUN/dgs/g' act-test.event > act-test.run
+	act -P $(ubuntu-latest) -W .github/workflows/local.yaml --eventpath act-test.run --detect-event; rm act-test.run
+
+.PHONY: test-federation-jvm
+test-federation-jvm:
+	sed 's/RUN/federation-jvm/g' act-test.event > act-test.run
+	act -P $(ubuntu-latest) -W .github/workflows/local.yaml --eventpath act-test.run --detect-event; rm act-test.run
+
+.PHONY: test-graphene
+test-graphene:
+	sed 's/RUN/graphene/g' act-test.event > act-test.run
+	act -P $(ubuntu-latest) -W .github/workflows/local.yaml --eventpath act-test.run --detect-event; rm act-test.run
+
+.PHONY: test-graphql-kotlin
+test-graphql-kotlin:
+	sed 's/RUN/graphql-kotlin/g' act-test.event > act-test.run
+	act -P $(ubuntu-latest) -W .github/workflows/local.yaml --eventpath act-test.run --detect-event; rm act-test.run
+
+.PHONY: test-php
+test-php:
+	sed 's/RUN/php/g' act-test.event > act-test.run
+	act -P $(ubuntu-latest) -W .github/workflows/local.yaml --eventpath act-test.run --detect-event; rm act-test.run
+
+.PHONY: test-ruby
+test-ruby:
+	sed 's/RUN/ruby/g' act-test.event > act-test.run
+	act -P $(ubuntu-latest) -W .github/workflows/local.yaml --eventpath act-test.run --detect-event; rm act-test.run
+
+.PHONY: test-stawberry-graphql
+test-stawberry-graphql:
+	sed 's/RUN/stawberry-graphql/g' act-test.event > act-test.run
+	act -P $(ubuntu-latest) -W .github/workflows/local.yaml --eventpath act-test.run --detect-event; rm act-test.run

--- a/act-test.event
+++ b/act-test.event
@@ -1,0 +1,6 @@
+{
+  "action": "workflow_dispatch",
+  "inputs": {
+      "implementation": "RUN"
+  }
+}


### PR DESCRIPTION
Note: split out CI error reporting to #47.

Local GitHub action tests via `act`:

- Using https://github.com/nektos/act
- Run GitHub actions locally in docker, for easier validation before pushing
- Essentially identical to GitHub action runners
- Use without having to install npm/node on your machine
  - `make test-apollo-server`
  - `make test-ariadne`
  - `make test-async-graphql`
  - `make test-dgs`
  - ...

Signed-off-by: Phil Prasek <prasek@gmail.com>