### PR TITLE
feat: switch to the router for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ node_modules/
 .idea/
 
 results.*
-supergraph.graphql
 
 ## Java/SpringBoot gitignore
 *#

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,12 +1,12 @@
 services:
   router:
-    image: ghcr.io/apollosolutions/gateway
+    image: ghcr.io/apollographql/router:v0.1.0-preview.2-debug
     volumes:
-      - ./supergraph.graphql:/etc/config/supergraph.graphql
-    environment:
-      - APOLLO_SCHEMA_CONFIG_EMBEDDED=/etc/config/supergraph.graphql
+      - ./router.yaml:/dist/config/router.yaml
+      - ./supergraph.graphql:/dist/config/supergraph.graphql
     ports:
       - 4000:4000
+    command: -c config/router.yaml -s config/supergraph.graphql
   inventory:
     image: apollo-federation-implementations/inventory
     ports:

--- a/router.yaml
+++ b/router.yaml
@@ -1,0 +1,5 @@
+server:
+  listen: 0.0.0.0:4000
+  cors:
+    allow_any_origin: true
+    allow_credentials: true

--- a/subgraphs/inventory/index.js
+++ b/subgraphs/inventory/index.js
@@ -23,8 +23,8 @@ const resolvers = {
     /** @type {(product: import('./typings').ProductReference, args: any, context: any) => any} */
     delivery: (product, args, context) => {
       // Validate Product has external information as per @requires
-      if (product.id != "federation")
-        throw new ApolloError("product.id was not 'federation'");
+      if (product.id != "apollo-federation")
+        throw new ApolloError("product.id was not 'apollo-federation'");
       if (product.dimensions.size != "1")
         throw new ApolloError("product.dimensions.size was not '1'");
       if (product.dimensions.weight != 1)

--- a/supergraph-fed2.graphql
+++ b/supergraph-fed2.graphql
@@ -1,0 +1,90 @@
+
+schema
+  @core(feature: "https://specs.apollo.dev/core/v0.2")
+  @core(feature: "https://specs.apollo.dev/join/v0.2", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @core(feature: String!, as: String, for: core__Purpose) repeatable on SCHEMA
+
+directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+enum core__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type DeliveryEstimates
+  @join__type(graph: INVENTORY)
+{
+  estimatedDelivery: String
+  fastestDelivery: String
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  INVENTORY @join__graph(name: "inventory", url: "http://inventory:4003")
+  PRODUCTS @join__graph(name: "products", url: "http://products:4001")
+  USERS @join__graph(name: "users", url: "http://users:4002")
+}
+
+type Product
+  @join__type(graph: INVENTORY, key: "id")
+  @join__type(graph: PRODUCTS, key: "id")
+  @join__type(graph: PRODUCTS, key: "sku package")
+  @join__type(graph: PRODUCTS, key: "sku variation { id }")
+{
+  id: ID!
+  dimensions: ProductDimension @join__field(graph: INVENTORY, external: true) @join__field(graph: PRODUCTS)
+  delivery(zip: String): DeliveryEstimates @join__field(graph: INVENTORY, requires: "dimensions { size weight }")
+  sku: String @join__field(graph: PRODUCTS)
+  package: String @join__field(graph: PRODUCTS)
+  variation: ProductVariation @join__field(graph: PRODUCTS)
+  createdBy: User @join__field(graph: PRODUCTS, provides: "totalProductsCreated")
+}
+
+type ProductDimension
+  @join__type(graph: INVENTORY)
+  @join__type(graph: PRODUCTS)
+{
+  size: String
+  weight: Float
+}
+
+type ProductVariation
+  @join__type(graph: PRODUCTS)
+{
+  id: ID!
+}
+
+type Query
+  @join__type(graph: INVENTORY)
+  @join__type(graph: PRODUCTS)
+  @join__type(graph: USERS)
+{
+  product(id: ID!): Product @join__field(graph: PRODUCTS)
+}
+
+type User
+  @join__type(graph: PRODUCTS, key: "email")
+  @join__type(graph: USERS, key: "email")
+{
+  email: ID!
+  totalProductsCreated: Int @join__field(graph: PRODUCTS, external: true) @join__field(graph: USERS)
+  name: String @join__field(graph: USERS)
+}

--- a/supergraph.graphql
+++ b/supergraph.graphql
@@ -1,0 +1,80 @@
+schema
+  @core(feature: "https://specs.apollo.dev/core/v0.2"),
+  @core(feature: "https://specs.apollo.dev/join/v0.1", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @core(as: String, feature: String!, for: core__Purpose) repeatable on SCHEMA
+
+directive @join__field(graph: join__Graph, provides: join__FieldSet, requires: join__FieldSet) on FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__owner(graph: join__Graph!) on INTERFACE | OBJECT
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet) repeatable on INTERFACE | OBJECT
+
+type DeliveryEstimates {
+  estimatedDelivery: String
+  fastestDelivery: String
+}
+
+type Product
+  @join__owner(graph: PRODUCTS)
+  @join__type(graph: PRODUCTS, key: "id")
+  @join__type(graph: PRODUCTS, key: "sku package")
+  @join__type(graph: PRODUCTS, key: "sku variation{id}")
+  @join__type(graph: INVENTORY, key: "id")
+{
+  createdBy: User @join__field(graph: PRODUCTS, provides: "totalProductsCreated")
+  delivery(zip: String): DeliveryEstimates @join__field(graph: INVENTORY, requires: "dimensions{size weight}")
+  dimensions: ProductDimension @join__field(graph: PRODUCTS)
+  id: ID! @join__field(graph: PRODUCTS)
+  package: String @join__field(graph: PRODUCTS)
+  sku: String @join__field(graph: PRODUCTS)
+  variation: ProductVariation @join__field(graph: PRODUCTS)
+}
+
+type ProductDimension {
+  size: String
+  weight: Float
+}
+
+type ProductVariation {
+  id: ID!
+}
+
+type Query {
+  product(id: ID!): Product @join__field(graph: PRODUCTS)
+}
+
+type User
+  @join__owner(graph: USERS)
+  @join__type(graph: USERS, key: "email")
+  @join__type(graph: PRODUCTS, key: "email")
+{
+  email: ID! @join__field(graph: USERS)
+  name: String @join__field(graph: USERS)
+  totalProductsCreated: Int @join__field(graph: USERS)
+}
+
+enum core__Purpose {
+  """
+  `EXECUTION` features provide metadata necessary to for operation execution.
+  """
+  EXECUTION
+
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  INVENTORY @join__graph(name: "inventory" url: "http://inventory:4003")
+  PRODUCTS @join__graph(name: "products" url: "http://products:4001")
+  USERS @join__graph(name: "users" url: "http://users:4002")
+}


### PR DESCRIPTION
The gateway-container project is effectively dead, but the Apollo Router project now publishes docker images. Apollo Router supports both Federation 1 and Federation 2 supergraphs.

This change also fixes a minor bug in the inventory supergraph, and adds both fed1 and fed2 supergraph schema files to the repo.

cc @hwillson 