### PR TITLE
[draft] federation-jvm:2.0.0

### DIFF
--- a/implementations/federation-jvm/pom.xml
+++ b/implementations/federation-jvm/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.apollographql.federation</groupId>
             <artifactId>federation-graphql-java-support</artifactId>
-            <version>2.0.0-alpha.5</version>
+            <version>2.0.0-alpha.6-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -85,6 +85,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.7</version>
             </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
@@ -100,4 +101,15 @@
             </plugin>
         </plugins>
     </build>
+
+    <repositories>
+        <repository>
+            <id>oss-snapshots</id>
+            <name>oss-snapshots</name>
+            <url> https://s01.oss.sonatype.org/content/repositories/snapshots/ </url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>

--- a/implementations/federation-jvm/src/main/resources/schemas/graphql-java/products.graphql
+++ b/implementations/federation-jvm/src/main/resources/schemas/graphql-java/products.graphql
@@ -1,6 +1,6 @@
 extend schema
   @link(url: "https://specs.apollo.dev/federation/v2.0",
-        import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override"])
+        import: ["@key", "@shareable", "@provides", "@external", { name: "@tag", as: "@apollo_tag" }, "@extends", "@override", "@inaccessible"])
 
 type Product
   @key(fields: "id")
@@ -12,7 +12,7 @@ type Product
   variation: ProductVariation
   dimensions: ProductDimension
   createdBy: User @provides(fields: "totalProductsCreated")
-  notes: String @tag(name: "internal")
+  notes: String @apollo_tag(name: "internal")
 }
 
 type ProductDimension @shareable {

--- a/src/tests/tag.test.ts
+++ b/src/tests/tag.test.ts
@@ -8,7 +8,7 @@ test("@tag", async () => {
   });
 
   const { sdl } = response.data._service;
-  expect(stripIgnoredCharacters(sdl)).toContain('@tag(name:"internal")');
+  expect(stripIgnoredCharacters(sdl)).toContain('@apollo_tag(name:"internal")');
 
   expect(compareSchemas(response.data?._service?.sdl)).toBe(true);
 });


### PR DESCRIPTION
This branch updates to `federation-jvm:2.0.0.alpha.6-SNAPSHOT`, which should be the exact same code as upcoming `2.0.0` and tests renaming directives. It's very crude as I believe it currently breaks all other tests and also uses SNAPSHOT which isn't a long term solution but at least it validates that federation-jvm works as expected for renaming directives