### PR TITLE
fix(appsync): set proper proxy_pass url and key

### DIFF
--- a/implementations/appsync/proxy/proxy.conf
+++ b/implementations/appsync/proxy/proxy.conf
@@ -3,7 +3,7 @@ server {
     server_name products;
     location / {
         proxy_ssl_server_name on;
-        proxy_set_header x-api-key "da2-ecovck5p4bhnxbqifgzcij7nk4";
-        proxy_pass https://fmbcmnnokfb6rd2bw2jyccef7i.appsync-api.eu-west-1.amazonaws.com/graphql;
+        proxy_set_header x-api-key "da2-nqpbtkycmbdjxnsqkuzorqbqca";
+        proxy_pass https://g7v5m2lnpnaatb45bpznpb6bom.appsync-api.eu-west-1.amazonaws.com/graphql;
     }
 }


### PR DESCRIPTION
This PR aim to fix AppSync tests by setting the proxy_pass url and key to the right value:

Before:
```
➜  apollo-federation-subgraph-compatibility git:(main) npm run test appsync

> test
> node dist/index.js "appsync"

Starting containers...
implementation under test failed to start
FetchError: request to http://localhost:4001/ failed, reason: connect ECONNREFUSED 127.0.0.1:4001
    at ClientRequest.<anonymous> (/Users/chazalf/amazon/GraphQLFederation/apollo-federation-subgraph-compatibility/node_modules/minipass-fetch/lib/index.js:110:14)
    at ClientRequest.emit (events.js:400:28)
    at Socket.socketErrorListener (_http_client.js:475:9)
    at Socket.emit (events.js:412:35)
    at emitErrorNT (internal/streams/destroy.js:106:8)
    at emitErrorCloseNT (internal/streams/destroy.js:74:3)
    at processTicksAndRejections (internal/process/task_queues.js:82:21) {
  code: 'ECONNREFUSED',
  errno: 'ECONNREFUSED',
  syscall: 'connect',
  address: '127.0.0.1',
  port: 4001,
  type: 'system'
}
Library appsync was not started successfully
Stopping containers...
complete
```

After:
```
➜  apollo-federation-subgraph-compatibility git:(main) ✗ npm run test appsync

> test
> node dist/index.js "appsync"

Starting containers...
Library appsync started successfully
Library appsync complete!
Stopping containers...
complete
```