### PR TITLE
AppSync Fed2 support

### DIFF
--- a/implementations/appsync/README.md
+++ b/implementations/appsync/README.md
@@ -11,7 +11,7 @@ To deploy your own version of this `products` service on AppSync you will need t
 
 1. deploy the cdk stack:
     ```sh
-    cd implementations/appsync/cdk/product-service
+    cd implementations/appsync/cdk/products-service
     npm install
     npm run build && npm run cdk deploy
 
@@ -21,23 +21,15 @@ To deploy your own version of this `products` service on AppSync you will need t
     ProductsServiceStack.AppSyncApiEndpoint = https://xxxxxxxxxxxxxxxxxxxx.appsync-api.eu-west-1.amazonaws.com/graphql
     ProductsServiceStack.AppSyncApiKey = da2-yyyyyyyyyyyyyyyyy
     ```
-1. Update nginx proxy conf `implementations/appsync/proxy/proxy.conf` with proper API_KEY and APPSYNC ENDPOINT:
-    ```nginx
-    server { 
-    listen 4001;
-    server_name products;
-    location / {
-        proxy_ssl_server_name on;
-        proxy_set_header x-api-key "<YOUR API_KEY>";
-        proxy_pass <YOUR APPSYNC ENDPOINT>;
-
-        }
-    }
+1. Add appsync details to env to be injected in docker image :
+    ```
+    export URL_APPSYNC=https://xxxxxxxxxxxxxxxxxxxx.appsync-api.eu-west-1.amazonaws.com/graphql
+    export API_KEY_APPSYNC=da2-yyyyyyyyyyyyyyyyy
     ```
 1. Launch nginx proxy container
     ```
     cd ../../../../
-    docker compose -f implementations/appsync/docker-compose.yaml up --build
+    docker compose -f docker-compose.yaml -f implementations/appsync/docker-compose.yaml up --build
     ```
 1. Launch the test
     ```sh

--- a/implementations/appsync/cdk/products-service/src/products-service-resolver.ts
+++ b/implementations/appsync/cdk/products-service/src/products-service-resolver.ts
@@ -6,7 +6,7 @@ const products = [
     sku: 'federation',
     package: '@apollo/federation',
     variation: { id: 'OSS' },
-    dimensions: { size: 'small', weight: 1 },
+    dimensions: { size: 'small', weight: 1, unit: "kg" },
   },
   {
     id: 'apollo-studio',
@@ -26,7 +26,7 @@ export const handler = async (event: AppSyncResolverEvent<any>) => {
       console.log(`dealing with product and field ${event.info.fieldName}`);
       switch (event.info.fieldName) {
         case 'createdBy':
-          result = { email: 'support@apollographql.com', name: 'Apollo Studio Support', totalProductsCreated: 1337 };
+          result = { email: 'support@apollographql.com', name: 'Jane Smith', totalProductsCreated: 1337 };
           break;
       }
       break;

--- a/implementations/appsync/cdk/products-service/src/products-service.graphql
+++ b/implementations/appsync/cdk/products-service/src/products-service.graphql
@@ -1,4 +1,5 @@
-schema {query: Query}
+
+schema @extends @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override"]) {query: Query}
 
 type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }") {
   id: ID!
@@ -7,11 +8,13 @@ type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku va
   variation: ProductVariation
   dimensions: ProductDimension
   createdBy: User @provides(fields: "totalProductsCreated")
+  notes: String @tag(name: "internal")
 }
 
-type ProductDimension {
+type ProductDimension @shareable {
   size: String
   weight: Float
+  unit: String @inaccessible
 }
 
 type _Service {
@@ -33,6 +36,7 @@ type Query @extends {
 
 type User @key(fields: "email") @extends {
   email: ID! @external
+  name: String @override(from: "users")
   totalProductsCreated: Int @external
 }
 


### PR DESCRIPTION
Update AppSync tests target to comply with Federation 2:

* add `@link` ,  `@shareable` , `@inaccessible`, `@tag` and `@override`
* Fix tests to return the right expected user's name and unit
* Fix README to comply with changes linked to move to github secrets