### PR TITLE
fix jest testrunner to evaluate all results

### DIFF
--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -49,11 +49,11 @@ export async function runJest(libraryName: string): Promise<JestResults> {
   const assertions = results.testResults.flatMap((x) => x.assertionResults);
   const assertionPassed = (name: string) => {
     return (
-      assertions.find((a: any) => {
+      !assertions.some((a: any) => {
         const assertionName =
           a.ancestorTitles.length === 0 ? a.fullName : a.ancestorTitles[0];
-        return assertionName === name;
-      })?.status === "passed"
+        return assertionName === name && a.status === "failed";
+      })
     );
   };
 


### PR DESCRIPTION
Current TestRunner was marking tests as successful if ANY of the Jest tests for given capability was successful. Updating logic to ensure that ALL tests for given capability are successful.