### PR TITLE
fix schema comparison tests

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -90,26 +90,44 @@ in your server (it is okay to return hardcoded results, this is what is done in
 `apollo-server` and `federation-jvm`).
 
 ```javascript
+const dimensions = [
+  {
+    size: "small",
+    weight: 1,
+    unit: "kg"
+  }
+]
+
+const users = [
+  {
+    email: "support@apollographql.com",
+    name: "Jane Smith",
+    totalProductsCreated: 1337,
+  },
+];
+
 const products = [
   {
     id: "apollo-federation",
     sku: "federation",
     package: "@apollo/federation",
-    variation: "OSS",
+    variation: {
+      id: "OSS"
+    },
+    dimensions: dimensions[0],
+    createdBy: users[0],
+    notes: null
   },
   {
     id: "apollo-studio",
     sku: "studio",
     package: "",
-    variation: "platform",
-  },
-];
-
-const users = [
-  {
-    email: "support@apollographql.com",
-    name: "Apollo Studio Support",
-    totalProductsCreated: 1337,
+    variation: {
+      id: "platform"
+    },
+    dimensions: dimensions[0],
+    createdBy: users[0],
+    notes: null
   },
 ];
 ```

--- a/src/tests/inaccessible.test.ts
+++ b/src/tests/inaccessible.test.ts
@@ -1,5 +1,4 @@
 import { productsRequest, graphqlRequest, ROUTER_URL } from "../utils/client";
-import { compareSchemas } from "../utils/schemaComparison";
 import { stripIgnoredCharacters } from "graphql";
 
 describe("@inaccessible", () => {
@@ -13,8 +12,6 @@ describe("@inaccessible", () => {
     const normalizedSDL = stripIgnoredCharacters(sdl); 
     expect(normalizedSDL).not.toContain("@federation__inaccessible");
     expect(normalizedSDL).toContain("unit:String@inaccessible");
-
-    expect(compareSchemas(response.data?._service?.sdl)).toBe(true);
   });
 
   it("should be able to query @inaccessible fields via the products schema directly", async () => {

--- a/src/tests/introspection.test.ts
+++ b/src/tests/introspection.test.ts
@@ -2,17 +2,16 @@ import { productsRequest } from "../utils/client";
 import { compareSchemas } from "../utils/schemaComparison";
 
 test("introspection", async () => {
-  const productsPing = await productsRequest({
+  const serviceSDLQuery = await productsRequest({
     query: "query { _service { sdl } }",
   });
 
-  expect(productsPing.data).toMatchObject({
+  expect(serviceSDLQuery.data).toMatchObject({
     _service: {
       sdl: expect.stringContaining("type Query"),
     },
   });
 
-  const basicallyTheSame = compareSchemas(productsPing.data?._service?.sdl);
-
+  const basicallyTheSame = compareSchemas(serviceSDLQuery.data?._service?.sdl);
   expect(basicallyTheSame).toBe(true);
 });

--- a/src/tests/link.test.ts
+++ b/src/tests/link.test.ts
@@ -1,5 +1,4 @@
 import { productsRequest } from "../utils/client";
-import { compareSchemas } from "../utils/schemaComparison";
 
 test("@link", async () => {
   const response = await productsRequest({
@@ -11,6 +10,4 @@ test("@link", async () => {
       sdl: expect.stringContaining("@link"),
     },
   });
-
-  expect(compareSchemas(response.data?._service?.sdl)).toBe(true);
 });

--- a/src/tests/override.test.ts
+++ b/src/tests/override.test.ts
@@ -1,5 +1,4 @@
-import { productsRequest, graphqlRequest, ROUTER_URL } from "../utils/client";
-import { compareSchemas } from "../utils/schemaComparison";
+import { productsRequest, routerRequest } from "../utils/client";
 import { stripIgnoredCharacters } from "graphql";
 
 describe("@override", () => {
@@ -10,12 +9,10 @@ describe("@override", () => {
 
     const { sdl } = response.data._service;
     expect(stripIgnoredCharacters(sdl)).toContain('@override(from:"users")');
-
-    expect(compareSchemas(response.data?._service?.sdl)).toBe(true);
   });
 
   it("should return overridden user name", async () => {
-    const resp = await graphqlRequest(ROUTER_URL, {
+    const resp = await routerRequest({
       query: `
         query GetProduct($id: ID!) {
           product(id: $id) {

--- a/src/tests/shareable.test.ts
+++ b/src/tests/shareable.test.ts
@@ -1,5 +1,4 @@
-import { productsRequest, graphqlRequest, ROUTER_URL } from "../utils/client";
-import { compareSchemas } from "../utils/schemaComparison";
+import { productsRequest, routerRequest } from "../utils/client";
 import { stripIgnoredCharacters } from "graphql";
 
 describe("@shareable", () => {
@@ -12,12 +11,10 @@ describe("@shareable", () => {
     expect(stripIgnoredCharacters(sdl)).toContain(
       "type ProductDimension@shareable"
     );
-
-    expect(compareSchemas(response.data?._service?.sdl)).toBe(true);
   });
 
   it("should be able to resolve @shareable ProductDimension types", async () => {
-    const resp = await graphqlRequest(ROUTER_URL, {
+    const resp = await routerRequest({
       query: `
         query GetProduct($id: ID!) {
           product(id: $id) {

--- a/src/tests/tag.test.ts
+++ b/src/tests/tag.test.ts
@@ -1,5 +1,4 @@
 import { productsRequest } from "../utils/client";
-import { compareSchemas } from "../utils/schemaComparison";
 import { stripIgnoredCharacters } from "graphql";
 
 test("@tag", async () => {
@@ -11,6 +10,4 @@ test("@tag", async () => {
   const normalizedSDL = stripIgnoredCharacters(sdl);
   expect(normalizedSDL).not.toContain('@federation__tag');
   expect(normalizedSDL).toContain('@tag(name:"internal")');
-
-  expect(compareSchemas(response.data?._service?.sdl)).toBe(true);
 });

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -43,6 +43,17 @@ export function productsRequest(
   return graphqlRequest(productsUrl, req, headers);
 }
 
+export function routerRequest(
+  req: {
+    query: string;
+    variables?: { [key: string]: any };
+    operationName?: string;
+  },
+  headers?: { [key: string]: any }
+) {
+  return graphqlRequest(ROUTER_URL, req, headers);
+}
+
 export async function ping(): Promise<boolean> {
   const routerPing = await fetch(routerHealthCheck, { retry: 10 });
 


### PR DESCRIPTION
Schema comparison was incorrectly comparing implemented schema against the expected schema only making basic comparisons and only checking for fields on the implemented schema.

Issues:
* If expected schema defined more elements or types they were never compared.
* If fields were non-nullable then tests were not comparing actual return types.
* Arguments were not compared

Schema comparison will now perform the following checks and return error summary if any of them fail:
* implementing type has to declare same amount of fields as expected one
* implementing type declares all the expected fields
* compares nullability of fields
* compares return type of fields
* compares arguments (nullability and type)

NOTE: Schema comparison does not currently work with lists as we don't have any list types defined in the schema.
NOTE2: Sadly Jest does not allow specifying custom messages to the assertions and does not support nested tests. `jest-expect-message` is unmaintained and not compatible with latest versions of Jest. Creating custom matcher seemed like an overkill so I made a workaround of capturing error messages into a string and expecting it to be empty.