### PR TITLE
update federation-jvm implementation with latest schema changes

### DIFF
--- a/implementations/federation-jvm/src/main/java/com/apollographql/federation/compatibility/GraphQLConfiguration.java
+++ b/implementations/federation-jvm/src/main/java/com/apollographql/federation/compatibility/GraphQLConfiguration.java
@@ -1,6 +1,7 @@
 package com.apollographql.federation.compatibility;
 
 import com.apollographql.federation.compatibility.model.Product;
+import com.apollographql.federation.compatibility.model.User;
 import com.apollographql.federation.graphqljava.Federation;
 import com.apollographql.federation.graphqljava._Entity;
 import com.apollographql.federation.graphqljava.tracing.FederatedTracingInstrumentation;
@@ -21,26 +22,30 @@ public class GraphQLConfiguration {
 
     @Bean
     public GraphQlSourceBuilderCustomizer federationTransform() {
-        return builder -> {
-            builder.schemaFactory((registry, wiring) ->
-                    Federation.transform(registry, wiring)
-                            .fetchEntities(env ->
-                                env.<List<Map<String, Object>>>getArgument(_Entity.argumentName).stream().map(reference -> {
-                                    if ("Product".equals(reference.get("__typename"))) {
-                                        return Product.resolveReference(reference);
-                                    }
+        return builder -> builder.schemaFactory((registry, wiring) ->
+                Federation.transform(registry, wiring)
+                        .fetchEntities(env ->
+                            env.<List<Map<String, Object>>>getArgument(_Entity.argumentName).stream().map(reference -> {
+                                if ("Product".equals(reference.get("__typename"))) {
+                                    return Product.resolveReference(reference);
+                                } else if ("User".equals(reference.get("__typename"))) {
+                                    return User.resolveReference(reference);
+                                } else {
                                     return null;
-                                }).collect(Collectors.toList())
-                            )
-                            .resolveEntityType(env -> {
-                                final Object src = env.getObject();
-                                if (src instanceof Product) {
-                                    return env.getSchema().getObjectType("Product");
                                 }
+                            }).collect(Collectors.toList())
+                        )
+                        .resolveEntityType(env -> {
+                            final Object src = env.getObject();
+                            if (src instanceof Product) {
+                                return env.getSchema().getObjectType("Product");
+                            } else if (src instanceof User) {
+                                return env.getSchema().getObjectType("User");
+                            } else {
                                 return null;
-                            })
-                            .build()
-            );
-        };
+                            }
+                        })
+                        .build()
+        );
     }
 }

--- a/implementations/federation-jvm/src/main/java/com/apollographql/federation/compatibility/UserController.java
+++ b/implementations/federation-jvm/src/main/java/com/apollographql/federation/compatibility/UserController.java
@@ -1,0 +1,18 @@
+package com.apollographql.federation.compatibility;
+
+import com.apollographql.federation.compatibility.model.User;
+import org.springframework.graphql.data.method.annotation.SchemaMapping;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class UserController {
+
+    @SchemaMapping(typeName="User", field="averageProductsCreatedPerYear")
+    public Integer getAverageProductsCreatedPerYear(User user) {
+        if (user.getTotalProductsCreated() != null) {
+            return Math.round(1.0f * user.getTotalProductsCreated() / user.getYearsOfEmployment());
+        } else {
+            return null;
+        }
+    }
+}

--- a/implementations/federation-jvm/src/main/java/com/apollographql/federation/compatibility/model/ProductDimension.java
+++ b/implementations/federation-jvm/src/main/java/com/apollographql/federation/compatibility/model/ProductDimension.java
@@ -18,4 +18,8 @@ public class ProductDimension {
     public float getWeight() {
         return weight;
     }
+
+    public String getUnit() {
+        return unit;
+    }
 }

--- a/implementations/federation-jvm/src/main/java/com/apollographql/federation/compatibility/model/User.java
+++ b/implementations/federation-jvm/src/main/java/com/apollographql/federation/compatibility/model/User.java
@@ -16,12 +16,6 @@ public class User {
         this.name = "Jane Smith";
     }
 
-    public User(String email, String name, Integer totalProductsCreated) {
-        this.email = email;
-        this.name = name;
-        this.totalProductsCreated = totalProductsCreated;
-    }
-
     public String getEmail() {
         return email;
     }
@@ -44,7 +38,7 @@ public class User {
 
     public static User resolveReference(@NotNull Map<String, Object> reference) {
         if (reference.get("email") instanceof String email) {
-            final User user = new User(email, "Jane Smith", 6);
+            final User user = new User(email);
             if (reference.get("yearsOfEmployment") instanceof Integer yearsOfEmployment) {
                 user.setYearsOfEmployment(yearsOfEmployment);
             }

--- a/implementations/federation-jvm/src/main/java/com/apollographql/federation/compatibility/model/User.java
+++ b/implementations/federation-jvm/src/main/java/com/apollographql/federation/compatibility/model/User.java
@@ -1,14 +1,25 @@
 package com.apollographql.federation.compatibility.model;
 
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+
 public class User {
     private final String email;
-    private final Integer totalProductsCreated;
     private final String name;
+    private final Integer totalProductsCreated;
+
+    private int yearsOfEmployment;
 
     public User(String email) {
         this.email = email;
         this.totalProductsCreated = 1337;
         this.name = "Jane Smith";
+    }
+
+    public User(String email, String name, Integer totalProductsCreated) {
+        this.email = email;
+        this.name = name;
+        this.totalProductsCreated = totalProductsCreated;
     }
 
     public String getEmail() {
@@ -21,5 +32,24 @@ public class User {
 
     public String getName() {
         return name;
+    }
+
+    public int getYearsOfEmployment() {
+        return yearsOfEmployment;
+    }
+
+    public void setYearsOfEmployment(int yearsOfEmployment) {
+        this.yearsOfEmployment = yearsOfEmployment;
+    }
+
+    public static User resolveReference(@NotNull Map<String, Object> reference) {
+        if (reference.get("email") instanceof String email) {
+            final User user = new User(email, "Jane Smith", 6);
+            if (reference.get("yearsOfEmployment") instanceof Integer yearsOfEmployment) {
+                user.setYearsOfEmployment(yearsOfEmployment);
+            }
+            return user;
+        }
+        return null;
     }
 }

--- a/implementations/federation-jvm/src/main/resources/graphql/schema.graphqls
+++ b/implementations/federation-jvm/src/main/resources/graphql/schema.graphqls
@@ -1,6 +1,6 @@
 extend schema
   @link(url: "https://specs.apollo.dev/federation/v2.0",
-        import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override", "@inaccessible"])
+        import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override", "@inaccessible", "@requires"])
 
 type Product
   @key(fields: "id")
@@ -30,7 +30,9 @@ type Query {
 }
 
 type User @key(fields: "email") @extends {
+  averageProductsCreatedPerYear: Int @requires(fields: "yearsOfEmployment")
   email: ID! @external
   name: String @override(from: "users")
   totalProductsCreated: Int @external
+  yearsOfEmployment: Int! @external
 }


### PR DESCRIPTION
Update to expected schema to enable verifying `@requires` directive functionality.

Changes:
* add missing `User` entity and type resolvers
* add `averageProductsCreatedPerYear: Int @requires(fields: "yearsOfEmployment")` on `User` type
* add new `yearsOfEmployment: Int! @external` field on `User` type`
* add missing `unit` getter on `ProductDimension`

Related Issues:
* https://github.com/apollographql/apollo-federation-subgraph-compatibility/issues/128