### PR TITLE
update apollo-server implementation with latest schema changes

### DIFF
--- a/implementations/apollo-server/products.graphql
+++ b/implementations/apollo-server/products.graphql
@@ -1,6 +1,6 @@
 extend schema
   @link(url: "https://specs.apollo.dev/federation/v2.0",
-        import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override", "@inaccessible"])
+        import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override", "@inaccessible", "@requires"])
 
 type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }") {
   id: ID!
@@ -27,7 +27,9 @@ type Query {
 }
 
 type User @key(fields: "email") @extends {
+  averageProductsCreatedPerYear: Int @requires(fields: "yearsOfEmployment")
   email: ID! @external
   name: String @override(from: "users")
   totalProductsCreated: Int @external
+  yearsOfEmployment: Int! @external
 }


### PR DESCRIPTION
Update to expected schema to enable verifying `@requires` directive functionality.

Changes:
* add missing `User` entity and type resolvers
* add `averageProductsCreatedPerYear: Int @requires(fields: "yearsOfEmployment")` on `User` type
* add new `yearsOfEmployment: Int! @external` field on `User` type`

Related Issues:

* https://github.com/apollographql/apollo-federation-subgraph-compatibility/issues/128