### PR TITLE
update graphql-kotlin implementation with latest schema changes

### DIFF
--- a/implementations/graphql-kotlin/build.gradle.kts
+++ b/implementations/graphql-kotlin/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
 dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-	implementation("com.expediagroup:graphql-kotlin-spring-server:6.0.0-alpha.5")
+	implementation("com.expediagroup:graphql-kotlin-spring-server:6.1.0")
 }
 
 tasks.withType<KotlinCompile> {

--- a/implementations/graphql-kotlin/src/main/kotlin/com/example/demo/DemoApplication.kt
+++ b/implementations/graphql-kotlin/src/main/kotlin/com/example/demo/DemoApplication.kt
@@ -1,146 +1,21 @@
 package com.example.demo
 
-import com.expediagroup.graphql.generator.annotations.GraphQLName
-import com.expediagroup.graphql.generator.federation.directives.*
-import com.expediagroup.graphql.generator.federation.execution.FederatedTypeResolver
-import com.expediagroup.graphql.generator.scalars.ID
-import com.expediagroup.graphql.server.operations.Query
-import graphql.schema.DataFetchingEnvironment
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import org.springframework.stereotype.Component
-import org.springframework.web.server.ServerWebExchange
+import org.springframework.context.annotation.Bean
 import org.springframework.web.server.WebFilter
-import org.springframework.web.server.WebFilterChain
-import reactor.core.publisher.Mono
 
-@KeyDirective(fields = FieldSet("id"))
-@KeyDirective(fields = FieldSet("sku package"))
-@KeyDirective(fields = FieldSet("sku variation { id }"))
-data class Product(
-    val id: ID,
-    val sku: String? = null,
-    @GraphQLName("package")
-    val pkg: String? = null,
-    val variation: ProductVariation? = null,
-    val dimensions: ProductDimension? = null,
-    @ProvidesDirective(FieldSet("totalProductsCreated"))
-    val createdBy: User? = null,
-    @TagDirective("internal")
-    val notes: String? = null
-) {
-    companion object {
-        fun byID(id: ID) = PRODUCTS.find { it.id.value == id.value }
-        private fun bySkuAndPackage(sku: String, pkg: String) = PRODUCTS.find { it.sku == sku && it.pkg == pkg }
-        private fun bySkuAndVariation(sku: String, variationId: String) =
-            PRODUCTS.find { it.sku == sku && it.variation?.id?.value == variationId }
+@SpringBootApplication
+class DemoApplication {
 
-        fun byReference(ref: Map<String, Any>): Product? {
-            val id = ref["id"]?.toString()
-            val sku = ref["sku"]?.toString()
-            val pkg = ref["package"]?.toString()
-            val variation = ref["variation"]
-            val variationId = if (variation is Map<*, *>) {
-                variation["id"].toString()
-            } else null
-
-            return when {
-                id != null -> byID(ID(id))
-                sku != null && pkg != null -> bySkuAndPackage(sku, pkg)
-                sku != null && variationId != null -> bySkuAndVariation(sku, variationId)
-                else -> throw RuntimeException("invalid entity reference")
-            }
-        }
-    }
-}
-
-val PRODUCTS = listOf(
-    Product(
-        ID("apollo-federation"),
-        "federation",
-        "@apollo/federation",
-        ProductVariation(ID("OSS")),
-        ProductDimension("small", 1.0f),
-        User(email = "support@apollographql.com", name = "support", totalProductsCreated = 1337)
-    ),
-    Product(
-        ID("apollo-studio"),
-        "studio",
-        "",
-        ProductVariation(ID("platform")),
-        ProductDimension("small", 1.0f),
-        User(email ="support@apollographql.com", name = "support", totalProductsCreated = 1337)
-    )
-)
-
-@ShareableDirective
-data class ProductDimension(
-    val size: String? = null,
-    val weight: Float? = null,
-    @InaccessibleDirective
-    val unit: String? = null
-)
-
-data class ProductVariation(
-    val id: ID
-)
-
-@KeyDirective(fields = FieldSet("email"))
-@ExtendsDirective
-data class User(
-    @ExternalDirective
-    val email: String,
-    @OverrideDirective(from = "users")
-    val name: String,
-    @ExternalDirective
-    val totalProductsCreated: Int? = null
-)
-
-@Component
-class ProductsResolver : FederatedTypeResolver<Product> {
-    override val typeName: String = "Product"
-
-    override suspend fun resolve(
-        environment: DataFetchingEnvironment,
-        representations: List<Map<String, Any>>
-    ): List<Product?> = representations.map {
-        Product.byReference(it)
-    }
-
-}
-
-@Component
-class UserResolver : FederatedTypeResolver<User> {
-    override val typeName: String = "User"
-
-    override suspend fun resolve(
-        environment: DataFetchingEnvironment,
-        representations: List<Map<String, Any>>
-    ): List<User?> {
-        return representations.map {
-            val email = it["email"]?.toString() ?: throw RuntimeException("invalid entity reference")
-            User(email = email, name = "default", totalProductsCreated = 1337)
-        }
-    }
-}
-
-@Component
-class ProductQuery : Query {
-    fun product(id: ID) = Product.byID(id)
-}
-
-@Component
-class CorsFilter : WebFilter {
-    override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
+    @Bean
+    fun corsFilter(): WebFilter = WebFilter { exchange, chain ->
         exchange.response.headers.add("Access-Control-Allow-Origin", "*")
         exchange.response.headers.add("Access-Control-Allow-Method", "GET, POST")
         exchange.response.headers.add("Access-Control-Allow-Headers", "content-type")
-        return chain.filter(exchange)
+        chain.filter(exchange)
     }
 }
-
-@SpringBootApplication
-class DemoApplication
 
 fun main(args: Array<String>) {
     runApplication<DemoApplication>(*args)

--- a/implementations/graphql-kotlin/src/main/kotlin/com/example/demo/ProductQuery.kt
+++ b/implementations/graphql-kotlin/src/main/kotlin/com/example/demo/ProductQuery.kt
@@ -1,0 +1,11 @@
+package com.example.demo
+
+import com.example.demo.model.Product
+import com.expediagroup.graphql.generator.scalars.ID
+import com.expediagroup.graphql.server.operations.Query
+import org.springframework.stereotype.Component
+
+@Component
+class ProductQuery : Query {
+    fun product(id: ID) = Product.byID(id)
+}

--- a/implementations/graphql-kotlin/src/main/kotlin/com/example/demo/model/Product.kt
+++ b/implementations/graphql-kotlin/src/main/kotlin/com/example/demo/model/Product.kt
@@ -1,0 +1,96 @@
+package com.example.demo.model
+
+import com.expediagroup.graphql.generator.annotations.GraphQLName
+import com.expediagroup.graphql.generator.federation.directives.FieldSet
+import com.expediagroup.graphql.generator.federation.directives.KeyDirective
+import com.expediagroup.graphql.generator.federation.directives.ProvidesDirective
+import com.expediagroup.graphql.generator.federation.directives.TagDirective
+import com.expediagroup.graphql.generator.federation.execution.FederatedTypeResolver
+import com.expediagroup.graphql.generator.scalars.ID
+import graphql.schema.DataFetchingEnvironment
+import org.springframework.stereotype.Component
+
+val PRODUCTS = listOf(
+    Product(
+        ID("apollo-federation"),
+        "federation",
+        "@apollo/federation",
+        ProductVariation(ID("OSS")),
+        ProductDimension("small", 1.0f, "kg"),
+        User(email = "support@apollographql.com", name = "Jane Smith", totalProductsCreated = 1337)
+    ),
+    Product(
+        ID("apollo-studio"),
+        "studio",
+        "",
+        ProductVariation(ID("platform")),
+        ProductDimension("small", 1.0f, "kg"),
+        User(email ="support@apollographql.com", name = "Jane Smith", totalProductsCreated = 1337)
+    )
+)
+
+/*
+type Product
+  @key(fields: "id")
+  @key(fields: "sku package")
+  @key(fields: "sku variation { id }") {
+  id: ID!
+  sku: String
+  package: String
+  variation: ProductVariation
+  dimensions: ProductDimension
+  createdBy: User @provides(fields: "totalProductsCreated")
+  notes: String @tag(name: "internal")
+}
+ */
+@KeyDirective(fields = FieldSet("id"))
+@KeyDirective(fields = FieldSet("sku package"))
+@KeyDirective(fields = FieldSet("sku variation { id }"))
+data class Product(
+    val id: ID,
+    val sku: String? = null,
+    @GraphQLName("package")
+    val pkg: String? = null,
+    val variation: ProductVariation? = null,
+    val dimensions: ProductDimension? = null,
+    @ProvidesDirective(FieldSet("totalProductsCreated"))
+    val createdBy: User? = null,
+    @TagDirective("internal")
+    val notes: String? = null
+) {
+    companion object {
+        fun byID(id: ID) = PRODUCTS.find { it.id.value == id.value }
+        private fun bySkuAndPackage(sku: String, pkg: String) = PRODUCTS.find { it.sku == sku && it.pkg == pkg }
+        private fun bySkuAndVariation(sku: String, variationId: String) =
+            PRODUCTS.find { it.sku == sku && it.variation?.id?.value == variationId }
+
+        fun byReference(ref: Map<String, Any>): Product? {
+            val id = ref["id"]?.toString()
+            val sku = ref["sku"]?.toString()
+            val pkg = ref["package"]?.toString()
+            val variation = ref["variation"]
+            val variationId = if (variation is Map<*, *>) {
+                variation["id"].toString()
+            } else null
+
+            return when {
+                id != null -> byID(ID(id))
+                sku != null && pkg != null -> bySkuAndPackage(sku, pkg)
+                sku != null && variationId != null -> bySkuAndVariation(sku, variationId)
+                else -> throw RuntimeException("invalid entity reference")
+            }
+        }
+    }
+}
+
+@Component
+class ProductsResolver : FederatedTypeResolver<Product> {
+    override val typeName: String = "Product"
+
+    override suspend fun resolve(
+        environment: DataFetchingEnvironment,
+        representations: List<Map<String, Any>>
+    ): List<Product?> = representations.map {
+        Product.byReference(it)
+    }
+}

--- a/implementations/graphql-kotlin/src/main/kotlin/com/example/demo/model/Product.kt
+++ b/implementations/graphql-kotlin/src/main/kotlin/com/example/demo/model/Product.kt
@@ -17,7 +17,7 @@ val PRODUCTS = listOf(
         "@apollo/federation",
         ProductVariation(ID("OSS")),
         ProductDimension("small", 1.0f, "kg"),
-        User(email = "support@apollographql.com", name = "Jane Smith", totalProductsCreated = 1337)
+        User(email = ID("support@apollographql.com"), name = "Jane Smith", totalProductsCreated = 1337)
     ),
     Product(
         ID("apollo-studio"),
@@ -25,7 +25,7 @@ val PRODUCTS = listOf(
         "",
         ProductVariation(ID("platform")),
         ProductDimension("small", 1.0f, "kg"),
-        User(email ="support@apollographql.com", name = "Jane Smith", totalProductsCreated = 1337)
+        User(email = ID("support@apollographql.com"), name = "Jane Smith", totalProductsCreated = 1337)
     )
 )
 

--- a/implementations/graphql-kotlin/src/main/kotlin/com/example/demo/model/ProductDimension.kt
+++ b/implementations/graphql-kotlin/src/main/kotlin/com/example/demo/model/ProductDimension.kt
@@ -1,0 +1,19 @@
+package com.example.demo.model
+
+import com.expediagroup.graphql.generator.federation.directives.InaccessibleDirective
+import com.expediagroup.graphql.generator.federation.directives.ShareableDirective
+
+/*
+type ProductDimension @shareable {
+  size: String
+  weight: Float
+  unit: String @inaccessible
+}
+ */
+@ShareableDirective
+data class ProductDimension(
+    val size: String? = null,
+    val weight: Float? = null,
+    @InaccessibleDirective
+    val unit: String? = null
+)

--- a/implementations/graphql-kotlin/src/main/kotlin/com/example/demo/model/ProductVariation.kt
+++ b/implementations/graphql-kotlin/src/main/kotlin/com/example/demo/model/ProductVariation.kt
@@ -1,0 +1,12 @@
+package com.example.demo.model
+
+import com.expediagroup.graphql.generator.scalars.ID
+
+/*
+type ProductVariation {
+  id: ID!
+}
+ */
+data class ProductVariation(
+    val id: ID
+)

--- a/implementations/graphql-kotlin/src/main/kotlin/com/example/demo/model/User.kt
+++ b/implementations/graphql-kotlin/src/main/kotlin/com/example/demo/model/User.kt
@@ -2,6 +2,7 @@ package com.example.demo.model
 
 import com.expediagroup.graphql.generator.federation.directives.*
 import com.expediagroup.graphql.generator.federation.execution.FederatedTypeResolver
+import com.expediagroup.graphql.generator.scalars.ID
 import graphql.schema.DataFetchingEnvironment
 import org.springframework.stereotype.Component
 import kotlin.math.roundToInt
@@ -20,9 +21,9 @@ extend type User @key(fields: "email") {
 @ExtendsDirective
 data class User(
     @ExternalDirective
-    val email: String,
+    val email: ID,
     @OverrideDirective(from = "users")
-    val name: String,
+    val name: String?,
     @ExternalDirective
     val totalProductsCreated: Int? = null
 ) {
@@ -47,7 +48,7 @@ class UserResolver : FederatedTypeResolver<User> {
     ): List<User?> {
         return representations.map {
             val email = it["email"]?.toString() ?: throw RuntimeException("invalid entity reference")
-            val user = User(email = email, name = "Jane Smith", totalProductsCreated = 1337)
+            val user = User(email = ID(email), name = "Jane Smith", totalProductsCreated = 1337)
 
             it["yearsOfEmployment"]?.toString()?.toIntOrNull()?.let { yearsOfEmployment ->
                 user.yearsOfEmployment = yearsOfEmployment

--- a/implementations/graphql-kotlin/src/main/kotlin/com/example/demo/model/User.kt
+++ b/implementations/graphql-kotlin/src/main/kotlin/com/example/demo/model/User.kt
@@ -1,0 +1,58 @@
+package com.example.demo.model
+
+import com.expediagroup.graphql.generator.federation.directives.*
+import com.expediagroup.graphql.generator.federation.execution.FederatedTypeResolver
+import graphql.schema.DataFetchingEnvironment
+import org.springframework.stereotype.Component
+import kotlin.math.roundToInt
+import kotlin.properties.Delegates
+
+/*
+extend type User @key(fields: "email") {
+  averageProductsCreatedPerYear: Int @requires(fields: "yearsOfEmployment")
+  email: ID! @external
+  name: String @override(from: "users")
+  totalProductsCreated: Int @external
+  yearsOfEmployment: Int! @external
+}
+ */
+@KeyDirective(fields = FieldSet("email"))
+@ExtendsDirective
+data class User(
+    @ExternalDirective
+    val email: String,
+    @OverrideDirective(from = "users")
+    val name: String,
+    @ExternalDirective
+    val totalProductsCreated: Int? = null
+) {
+    @ExternalDirective
+    var yearsOfEmployment: Int by Delegates.notNull()
+
+    @RequiresDirective(fields = FieldSet("yearsOfEmployment"))
+    fun averageProductsCreatedPerYear(): Int? = if (totalProductsCreated != null) {
+        (1.0f * totalProductsCreated / yearsOfEmployment).roundToInt()
+    } else {
+        null
+    }
+}
+
+@Component
+class UserResolver : FederatedTypeResolver<User> {
+    override val typeName: String = "User"
+
+    override suspend fun resolve(
+        environment: DataFetchingEnvironment,
+        representations: List<Map<String, Any>>
+    ): List<User?> {
+        return representations.map {
+            val email = it["email"]?.toString() ?: throw RuntimeException("invalid entity reference")
+            val user = User(email = email, name = "Jane Smith", totalProductsCreated = 1337)
+
+            it["yearsOfEmployment"]?.toString()?.toIntOrNull()?.let { yearsOfEmployment ->
+                user.yearsOfEmployment = yearsOfEmployment
+            }
+            user;
+        }
+    }
+}


### PR DESCRIPTION
Update to expected schema that verifies `@requires` directive functionality.

Changes:

* split code into separate class for easier maintainability
* add missing `ProductDimension.unit` value
* update `User.email` return type to `ID!` (from `String!`) 
* update `User.name` return type to nullable `String?`
* add `averageProductsCreatedPerYear: Int @requires(fields: "yearsOfEmployment")` on `User` type
* add new `yearsOfEmployment: Int! @external` field on `User` type`

Related Issues:

* https://github.com/apollographql/apollo-federation-subgraph-compatibility/issues/128