### PR TITLE
update graphql-java-kickstart implementation with latest schema changes

### DIFF
--- a/implementations/graphql-java-kickstart/src/main/java/graphql/kickstart/federation/compatibility/federation/FederatedSchema.java
+++ b/implementations/graphql-java-kickstart/src/main/java/graphql/kickstart/federation/compatibility/federation/FederatedSchema.java
@@ -3,7 +3,9 @@ package graphql.kickstart.federation.compatibility.federation;
 import com.apollographql.federation.graphqljava.Federation;
 import com.apollographql.federation.graphqljava._Entity;
 import graphql.kickstart.federation.compatibility.model.Product;
+import graphql.kickstart.federation.compatibility.model.User;
 import graphql.kickstart.federation.compatibility.resolvers.ProductReferenceResolver;
+import graphql.kickstart.federation.compatibility.resolvers.UserReferenceResolver;
 import graphql.kickstart.tools.SchemaParser;
 import graphql.schema.GraphQLSchema;
 import java.util.List;
@@ -18,28 +20,30 @@ public class FederatedSchema {
 
     @Bean
     public GraphQLSchema federatedGraphQLSchema(SchemaParser schemaParser) {
-        String federationTypeName = "Product";
-
         // TODO FIXME: kickstart executable schema doesn't contain schema directives, so the @link tests currently fail :'(
         return Federation.transform(schemaParser.makeExecutableSchema())
-            .fetchEntities(env -> env.<List<Map<String, Object>>>getArgument(_Entity.argumentName)
-                .stream()
-                .map(reference -> {
-                    if (federationTypeName.equals(reference.get("__typename"))) {
-                        return ProductReferenceResolver.resolveReference(reference);
+                .fetchEntities(env ->
+                        env.<List<Map<String, Object>>>getArgument(_Entity.argumentName).stream().map(reference -> {
+                            if ("Product".equals(reference.get("__typename"))) {
+                                return ProductReferenceResolver.resolveReference(reference);
+                            } else if ("User".equals(reference.get("__typename"))) {
+                                return UserReferenceResolver.resolveReference(reference);
+                            } else {
+                                return null;
+                            }
+                        }).collect(Collectors.toList())
+                )
+                .resolveEntityType(env -> {
+                    final Object src = env.getObject();
+                    if (src instanceof Product) {
+                        return env.getSchema().getObjectType("Product");
+                    } else if (src instanceof User) {
+                        return env.getSchema().getObjectType("User");
+                    } else {
+                        return null;
                     }
-                    return null;
                 })
-                .collect(Collectors.toList()))
-            .resolveEntityType(env -> {
-                final Object src = env.getObject();
-                if (src instanceof Product) {
-                    return env.getSchema()
-                        .getObjectType(federationTypeName);
-                }
-                return null;
-            })
-            .build();
+                .build();
     }
 }
 

--- a/implementations/graphql-java-kickstart/src/main/java/graphql/kickstart/federation/compatibility/model/Product.java
+++ b/implementations/graphql-java-kickstart/src/main/java/graphql/kickstart/federation/compatibility/model/Product.java
@@ -19,7 +19,7 @@ public class Product {
         this.sku = "";
         this.productPackage = "";
         this.variation = new ProductVariation("");
-        this.dimensions = new ProductDimension("small", 1, "unit");
+        this.dimensions = new ProductDimension("small", 1, "kg");
         this.createdBy = new User("support@apollographql.com");
         this.notes = "";
     }
@@ -29,7 +29,7 @@ public class Product {
         this.sku = sku;
         this.productPackage = productPackage;
         this.variation = new ProductVariation(variationId);
-        this.dimensions = new ProductDimension("small", 1, "unit");
+        this.dimensions = new ProductDimension("small", 1, "kg");
         this.createdBy = new User("support@apollographql.com");
         this.notes = "";
     }
@@ -39,7 +39,7 @@ public class Product {
         this.sku = sku;
         this.productPackage = productPackage;
         this.variation = new ProductVariation("");
-        this.dimensions = new ProductDimension("small", 1, "unit");
+        this.dimensions = new ProductDimension("small", 1, "kg");
         this.createdBy = new User("support@apollographql.com");
         this.notes = "";
     }
@@ -49,7 +49,7 @@ public class Product {
         this.productPackage = "";
         this.sku = sku;
         this.variation = variation;
-        this.dimensions = new ProductDimension("small", 1, "unit");
+        this.dimensions = new ProductDimension("small", 1, "kg");
         this.createdBy = new User("support@apollographql.com");
         this.notes = "";
     }

--- a/implementations/graphql-java-kickstart/src/main/java/graphql/kickstart/federation/compatibility/model/User.java
+++ b/implementations/graphql-java-kickstart/src/main/java/graphql/kickstart/federation/compatibility/model/User.java
@@ -6,13 +6,18 @@ import lombok.Getter;
 public class User {
 
     private final String email;
-    private final Integer totalProductsCreated;
     private final String name;
+    private final Integer totalProductsCreated;
+
+    private int yearsOfEmployment = -1;
 
     public User(String email) {
         this.email = email;
-        this.totalProductsCreated = 1337;
         this.name = "Jane Smith";
+        this.totalProductsCreated = 1337;
     }
 
+    public void setYearsOfEmployment(int yearsOfEmployment) {
+        this.yearsOfEmployment = yearsOfEmployment;
+    }
 }

--- a/implementations/graphql-java-kickstart/src/main/java/graphql/kickstart/federation/compatibility/resolvers/ProductReferenceResolver.java
+++ b/implementations/graphql-java-kickstart/src/main/java/graphql/kickstart/federation/compatibility/resolvers/ProductReferenceResolver.java
@@ -11,19 +11,15 @@ import org.springframework.stereotype.Component;
 public class ProductReferenceResolver {
 
     public static Product resolveReference(@NotNull Map<String, Object> reference) {
-        if (reference.get("id") instanceof String) {
-            String productId = (String) reference.get("id");
+        if (reference.get("id") instanceof String productId) {
             for (Product product : ProductService.products) {
                 if (product.getId()
                     .equals(productId)) {
                     return product;
                 }
             }
-        } else {
-            String productSku = (String) reference.get("sku");
-
-            if (reference.get("package") instanceof String) {
-                String productPackage = (String) reference.get("package");
+        } else if (reference.get("sku") instanceof String productSku) {
+            if (reference.get("package") instanceof String productPackage) {
                 for (Product product : ProductService.products) {
                     if (product.getSku()
                         .equals(productSku) && product.getProductPackage()
@@ -31,8 +27,7 @@ public class ProductReferenceResolver {
                         return product;
                     }
                 }
-            } else if (reference.get("variation") instanceof HashMap) {
-                var productVariation = (HashMap) reference.get("variation");
+            } else if (reference.get("variation") instanceof HashMap productVariation) {
                 for (Product product : ProductService.products) {
                     if (product.getSku()
                         .equals(productSku) && product.getVariation()

--- a/implementations/graphql-java-kickstart/src/main/java/graphql/kickstart/federation/compatibility/resolvers/UserReferenceResolver.java
+++ b/implementations/graphql-java-kickstart/src/main/java/graphql/kickstart/federation/compatibility/resolvers/UserReferenceResolver.java
@@ -1,0 +1,22 @@
+package graphql.kickstart.federation.compatibility.resolvers;
+
+import graphql.kickstart.federation.compatibility.model.User;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserReferenceResolver {
+
+    public static User resolveReference(@NotNull Map<String, Object> reference) {
+        if (reference.get("email") instanceof String email) {
+            final User user = new User(email);
+            if (reference.get("yearsOfEmployment") instanceof Integer yearsOfEmployment) {
+                user.setYearsOfEmployment(yearsOfEmployment);
+            }
+            return user;
+        }
+
+        return null;
+    }
+}

--- a/implementations/graphql-java-kickstart/src/main/java/graphql/kickstart/federation/compatibility/resolvers/UserResolver.java
+++ b/implementations/graphql-java-kickstart/src/main/java/graphql/kickstart/federation/compatibility/resolvers/UserResolver.java
@@ -1,0 +1,17 @@
+package graphql.kickstart.federation.compatibility.resolvers;
+
+import graphql.kickstart.federation.compatibility.model.User;
+import graphql.kickstart.tools.GraphQLResolver;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserResolver implements GraphQLResolver<User> {
+
+    public Integer getAverageProductsCreatedPerYear(User user) {
+        if (user.getTotalProductsCreated() != null) {
+            return Math.round(1.0f * user.getTotalProductsCreated() / user.getYearsOfEmployment());
+        } else {
+            return null;
+        }
+    }
+}

--- a/implementations/graphql-java-kickstart/src/main/resources/schemas/products.graphql
+++ b/implementations/graphql-java-kickstart/src/main/resources/schemas/products.graphql
@@ -1,9 +1,8 @@
 extend schema
 @link(url: "https://specs.apollo.dev/federation/v2.0",
-    import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override", "@inaccessible"])
+    import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override", "@inaccessible", "@requires"])
 
-type Product
-@key(fields: "id") {
+type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }") {
     id: ID!
     sku: String
     package: String
@@ -28,7 +27,9 @@ type Query {
 }
 
 type User @key(fields: "email") @extends {
+    averageProductsCreatedPerYear: Int @requires(fields: "yearsOfEmployment")
     email: ID! @external
     name: String @override(from: "users")
     totalProductsCreated: Int @external
+    yearsOfEmployment: Int! @external
 }


### PR DESCRIPTION
Update to expected schema that verifies `@requires` directive functionality.

Changes:

* add missing `User` entity type resolver
* correct `ProductDimension.unit` return value
* add `averageProductsCreatedPerYear: Int @requires(fields: "yearsOfEmployment")` on `User` type
* add new `yearsOfEmployment: Int! @external` field on `User` type`

NOTE: `@link` test is still failing as `graphql-java-tools` currently does not support schema directives

Related Issues:

* https://github.com/apollographql/apollo-federation-subgraph-compatibility/issues/128