### PR TITLE
Update version of strawberry

### DIFF
--- a/implementations/strawberry-graphql/requirements.txt
+++ b/implementations/strawberry-graphql/requirements.txt
@@ -1,1 +1,1 @@
-strawberry-graphql[debug-server]==0.111.0
+strawberry-graphql[debug-server]==0.124.0

--- a/implementations/strawberry-graphql/server.py
+++ b/implementations/strawberry-graphql/server.py
@@ -137,4 +137,4 @@ class Query:
     product: Optional[Product] = strawberry.field(resolver=get_product_by_id)
 
 
-schema = strawberry.federation.Schema(query=Query)
+schema = strawberry.federation.Schema(query=Query, enable_federation_2=True)


### PR DESCRIPTION
This PR updates strawberry to 0.124.0, which improves the support for federation 2. The main change is the support for the link directive, which is also automatically added when opting into federation 2.

I've also updated the schema with support for `override` and fixed a couple of bugs 😊