### PR TITLE
updating @requires to explicitly reference all fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ extend type Query {
 }
 
 extend type User @key(fields: "email") {
-  averageProductsCreatedPerYear: Int @requires(fields: "yearsOfEmployment")
+  averageProductsCreatedPerYear: Int @requires(fields: "totalProductsCreated yearsOfEmployment")
   email: ID! @external
   name: String @override(from: "users")
   totalProductsCreated: Int @external

--- a/implementations/_template_hosted_/products.graphql
+++ b/implementations/_template_hosted_/products.graphql
@@ -29,7 +29,7 @@ extend type Query {
 }
 
 extend type User @key(fields: "email") {
-  averageProductsCreatedPerYear: Int @requires(fields: "yearsOfEmployment")
+  averageProductsCreatedPerYear: Int @requires(fields: "totalProductsCreated yearsOfEmployment")
   email: ID! @external
   name: String @override(from: "users")
   totalProductsCreated: Int @external

--- a/implementations/_template_library_/products.graphql
+++ b/implementations/_template_library_/products.graphql
@@ -29,7 +29,7 @@ extend type Query {
 }
 
 extend type User @key(fields: "email") {
-  averageProductsCreatedPerYear: Int @requires(fields: "yearsOfEmployment")
+  averageProductsCreatedPerYear: Int @requires(fields: "totalProductsCreated yearsOfEmployment")
   email: ID! @external
   name: String @override(from: "users")
   totalProductsCreated: Int @external

--- a/implementations/apollo-server/index.js
+++ b/implementations/apollo-server/index.js
@@ -69,6 +69,9 @@ const resolvers = {
     __resolveReference: (reference) => {
       if (reference.email) {
         const user = { email: reference.email, name: "Jane Smith", totalProductsCreated: 1337 };
+        if (reference.totalProductsCreated) {
+          user.totalProductsCreated = reference.totalProductsCreated;
+        }
         if (reference.yearsOfEmployment) {
           // @ts-ignore
           user.yearsOfEmployment = reference.yearsOfEmployment;

--- a/implementations/apollo-server/products.graphql
+++ b/implementations/apollo-server/products.graphql
@@ -27,7 +27,7 @@ type Query {
 }
 
 type User @key(fields: "email") @extends {
-  averageProductsCreatedPerYear: Int @requires(fields: "yearsOfEmployment")
+  averageProductsCreatedPerYear: Int @requires(fields: "totalProductsCreated yearsOfEmployment")
   email: ID! @external
   name: String @override(from: "users")
   totalProductsCreated: Int @external

--- a/implementations/dgs/src/main/java/com/netflix/graphql/dgs/compatibility/datafetchers/UserDataFetcher.java
+++ b/implementations/dgs/src/main/java/com/netflix/graphql/dgs/compatibility/datafetchers/UserDataFetcher.java
@@ -25,6 +25,9 @@ public class UserDataFetcher {
   public static User resolveReference(@NotNull Map<String, Object> reference) {
     if (reference.get("email") instanceof String email) {
       final User user = new User(email);
+      if (reference.get("totalProductsCreated") instanceof Integer totalProductsCreated) {
+        user.setTotalProductsCreated(totalProductsCreated);
+      }
       if (reference.get("yearsOfEmployment") instanceof Integer yearsOfEmployment) {
         user.setYearsOfEmployment(yearsOfEmployment);
       }

--- a/implementations/dgs/src/main/java/com/netflix/graphql/dgs/compatibility/model/User.java
+++ b/implementations/dgs/src/main/java/com/netflix/graphql/dgs/compatibility/model/User.java
@@ -3,7 +3,7 @@ package com.netflix.graphql.dgs.compatibility.model;
 public class User {
     private final String email;
     private final String name;
-    private final Integer totalProductsCreated;
+    private Integer totalProductsCreated;
 
     private int yearsOfEmployment = -1;
 
@@ -23,6 +23,10 @@ public class User {
 
     public Integer getTotalProductsCreated() {
         return totalProductsCreated;
+    }
+
+    public void setTotalProductsCreated(Integer totalProductsCreated) {
+        this.totalProductsCreated = totalProductsCreated;
     }
 
     public int getYearsOfEmployment() {

--- a/implementations/dgs/src/main/resources/schema/products.graphql
+++ b/implementations/dgs/src/main/resources/schema/products.graphql
@@ -27,7 +27,7 @@ type Query {
 }
 
 type User @key(fields: "email") @extends {
-  averageProductsCreatedPerYear: Int @requires(fields: "yearsOfEmployment")
+  averageProductsCreatedPerYear: Int @requires(fields: "totalProductsCreated yearsOfEmployment")
   email: ID! @external
   name: String @override(from: "users")
   totalProductsCreated: Int @external

--- a/implementations/federation-jvm/src/main/java/com/apollographql/federation/compatibility/model/User.java
+++ b/implementations/federation-jvm/src/main/java/com/apollographql/federation/compatibility/model/User.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
 public class User {
     private final String email;
     private final String name;
-    private final Integer totalProductsCreated;
+    private Integer totalProductsCreated;
 
     private int yearsOfEmployment;
 
@@ -20,12 +20,16 @@ public class User {
         return email;
     }
 
+    public String getName() {
+        return name;
+    }
+
     public Integer getTotalProductsCreated() {
         return totalProductsCreated;
     }
 
-    public String getName() {
-        return name;
+    public void setTotalProductsCreated(Integer totalProductsCreated) {
+        this.totalProductsCreated = totalProductsCreated;
     }
 
     public int getYearsOfEmployment() {
@@ -39,6 +43,9 @@ public class User {
     public static User resolveReference(@NotNull Map<String, Object> reference) {
         if (reference.get("email") instanceof String email) {
             final User user = new User(email);
+            if (reference.get("totalProductsCreated") instanceof Integer totalProductsCreated) {
+                user.setTotalProductsCreated(totalProductsCreated);
+            }
             if (reference.get("yearsOfEmployment") instanceof Integer yearsOfEmployment) {
                 user.setYearsOfEmployment(yearsOfEmployment);
             }

--- a/implementations/federation-jvm/src/main/resources/graphql/schema.graphqls
+++ b/implementations/federation-jvm/src/main/resources/graphql/schema.graphqls
@@ -30,7 +30,7 @@ type Query {
 }
 
 type User @key(fields: "email") @extends {
-  averageProductsCreatedPerYear: Int @requires(fields: "yearsOfEmployment")
+  averageProductsCreatedPerYear: Int @requires(fields: "totalProductsCreated yearsOfEmployment")
   email: ID! @external
   name: String @override(from: "users")
   totalProductsCreated: Int @external

--- a/implementations/graphql-java-kickstart/src/main/java/graphql/kickstart/federation/compatibility/model/User.java
+++ b/implementations/graphql-java-kickstart/src/main/java/graphql/kickstart/federation/compatibility/model/User.java
@@ -7,7 +7,7 @@ public class User {
 
     private final String email;
     private final String name;
-    private final Integer totalProductsCreated;
+    private Integer totalProductsCreated;
 
     private int yearsOfEmployment = -1;
 
@@ -15,6 +15,10 @@ public class User {
         this.email = email;
         this.name = "Jane Smith";
         this.totalProductsCreated = 1337;
+    }
+
+    public void setTotalProductsCreated(Integer totalProductsCreated) {
+        this.totalProductsCreated = totalProductsCreated;
     }
 
     public void setYearsOfEmployment(int yearsOfEmployment) {

--- a/implementations/graphql-java-kickstart/src/main/java/graphql/kickstart/federation/compatibility/resolvers/UserReferenceResolver.java
+++ b/implementations/graphql-java-kickstart/src/main/java/graphql/kickstart/federation/compatibility/resolvers/UserReferenceResolver.java
@@ -11,6 +11,9 @@ public class UserReferenceResolver {
     public static User resolveReference(@NotNull Map<String, Object> reference) {
         if (reference.get("email") instanceof String email) {
             final User user = new User(email);
+            if (reference.get("totalProductsCreated") instanceof Integer totalProductsCreated) {
+                user.setTotalProductsCreated(totalProductsCreated);
+            }
             if (reference.get("yearsOfEmployment") instanceof Integer yearsOfEmployment) {
                 user.setYearsOfEmployment(yearsOfEmployment);
             }

--- a/implementations/graphql-java-kickstart/src/main/resources/schemas/products.graphql
+++ b/implementations/graphql-java-kickstart/src/main/resources/schemas/products.graphql
@@ -27,7 +27,7 @@ type Query {
 }
 
 type User @key(fields: "email") @extends {
-    averageProductsCreatedPerYear: Int @requires(fields: "yearsOfEmployment")
+    averageProductsCreatedPerYear: Int @requires(fields: "totalProductsCreated yearsOfEmployment")
     email: ID! @external
     name: String @override(from: "users")
     totalProductsCreated: Int @external


### PR DESCRIPTION
`User.averageProductsCreatedPerYear` requires both `totalProductsCreated` and `yearsOfEmployment` fields to calculate its value but directive only specifies the latter (`@requires(fields: "yearsOfEmployment")`). This is because `totalProductsCreated` is only accessible through `Product.createdBy` field that is annotated with `@provides(fields: "totalProductsCreated")` that implies it is always a local field. If `User` type was accessible through other paths, then `totalProductsCreated` would have to be provided from other part of the graph.

Updating expected test schema to explicitly specify both fields to avoid any ambiguity around this. Updating applied directive value to `@requires(fields: "totalProductsCreated yearsOfEmployment")`.