### PR TITLE
update supergraph schema to reflect latest changes

### DIFF
--- a/supergraph.graphql
+++ b/supergraph.graphql
@@ -94,7 +94,7 @@ type User
   @join__type(graph: PRODUCTS, key: "email", extension: true)
   @join__type(graph: USERS, key: "email")
 {
-  averageProductsCreatedPerYear: Int @join__field(graph: PRODUCTS, requires: "yearsOfEmployment")
+  averageProductsCreatedPerYear: Int @join__field(graph: PRODUCTS, requires: "totalProductsCreated yearsOfEmployment")
   email: ID!
   name: String @join__field(graph: PRODUCTS, override: "users")
   totalProductsCreated: Int @join__field(graph: PRODUCTS, external: true) @join__field(graph: USERS)


### PR DESCRIPTION
Supergraph schema was not regernerated after we made the change in https://github.com/apollographql/apollo-federation-subgraph-compatibility/pull/160. This lead to old behavior (i.e. not including `totalProductsCreated` in the entity representation).