### PR TITLE
update product subgraph test schema with additional @key test cases

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -90,27 +90,47 @@ in your server (it is okay to return hardcoded results, this is what is done in
 `apollo-server` and `federation-jvm`).
 
 ```javascript
-const dimensions = [
-  {
-    size: "small",
-    weight: 1,
-    unit: "kg"
-  }
-]
+const dimension = {
+  size: "small",
+  weight: 1,
+  unit: "kg"
+}
 
-const users = [
-  {
-    averageProductsCreatedPerYear: if (totalProductsCreated) { 
-       Math.round(totalProductsCreated / yearsOfEmployment)
-    } else { 
-      null
-    },
-    email: "support@apollographql.com",
-    name: "Jane Smith",
-    totalProductsCreated: 1337,
-    yearsOfEmployment: 10
+const user = {
+  averageProductsCreatedPerYear: if (totalProductsCreated) { 
+    Math.round(totalProductsCreated / yearsOfEmployment)
+  } else { 
+    null
   },
-];
+  email: "support@apollographql.com",
+  name: "Jane Smith",
+  totalProductsCreated: 1337,
+  yearsOfEmployment: 10
+ };
+
+ const deprecatedProduct = {
+  sku: "apollo-federation-v1",
+  package: "@apollo/federation-v1",
+  reason: "Migrate to Federation V2",
+  createdBy: user
+};
+
+const productsResearch = [
+  {
+    study: {
+      caseNumber: "1234",
+      description: "Federation Study"
+    },
+    outcome: null
+  },
+  {
+    study: {
+      caseNumber: "1235",
+      description: "Studio Study"
+    },
+    outcome: null
+  },
+]
 
 const products = [
   {
@@ -120,8 +140,9 @@ const products = [
     variation: {
       id: "OSS"
     },
-    dimensions: dimensions[0],
-    createdBy: users[0],
+    dimensions: dimension,
+    research: [productsResearch[0]]
+    createdBy: user,
     notes: null
   },
   {
@@ -131,8 +152,9 @@ const products = [
     variation: {
       id: "platform"
     },
-    dimensions: dimensions[0],
-    createdBy: users[0],
+    dimensions: dimension,
+    research: [productsResearch[1]]
+    createdBy: user,
     notes: null
   },
 ];

--- a/implementations/_template_hosted_/products.graphql
+++ b/implementations/_template_hosted_/products.graphql
@@ -1,8 +1,8 @@
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.0",
-        import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override", "@inaccessible", "@requires"])
-
-directive @override(from: String!) on FIELD_DEFINITION
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.0",
+    import: ["@extends", "@external", "@inaccessible", "@key", "@override", "@provides", "@requires", "@shareable", "@tag"]
+  )
 
 type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }") {
   id: ID!
@@ -12,10 +12,28 @@ type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku va
   dimensions: ProductDimension
   createdBy: User @provides(fields: "totalProductsCreated")
   notes: String @tag(name: "internal")
+  research: [ProductResearch!]!
+}
+
+type DeprecatedProduct @key(fields: "sku package") {
+  sku: String!
+  package: String!
+  reason: String
+  createdBy: User
 }
 
 type ProductVariation {
   id: ID!
+}
+
+type ProductResearch @key(fields: "study { caseNumber }") {
+  study: CaseStudy!
+  outcome: String
+}
+
+type CaseStudy {
+  caseNumber: ID!
+  description: String
 }
 
 type ProductDimension @shareable {
@@ -26,6 +44,7 @@ type ProductDimension @shareable {
 
 extend type Query {
   product(id: ID!): Product
+  deprecatedProduct(sku: String!, package: String!): DeprecatedProduct @deprecated(reason: "Use product query instead")
 }
 
 extend type User @key(fields: "email") {

--- a/implementations/_template_library_/products.graphql
+++ b/implementations/_template_library_/products.graphql
@@ -1,8 +1,8 @@
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.0",
-        import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override", "@inaccessible", "@requires"])
-
-directive @override(from: String!) on FIELD_DEFINITION
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.0",
+    import: ["@extends", "@external", "@inaccessible", "@key", "@override", "@provides", "@requires", "@shareable", "@tag"]
+  )
 
 type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }") {
   id: ID!
@@ -12,10 +12,28 @@ type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku va
   dimensions: ProductDimension
   createdBy: User @provides(fields: "totalProductsCreated")
   notes: String @tag(name: "internal")
+  research: [ProductResearch!]!
+}
+
+type DeprecatedProduct @key(fields: "sku package") {
+  sku: String!
+  package: String!
+  reason: String
+  createdBy: User
 }
 
 type ProductVariation {
   id: ID!
+}
+
+type ProductResearch @key(fields: "study { caseNumber }") {
+  study: CaseStudy!
+  outcome: String
+}
+
+type CaseStudy {
+  caseNumber: ID!
+  description: String
 }
 
 type ProductDimension @shareable {
@@ -26,6 +44,7 @@ type ProductDimension @shareable {
 
 extend type Query {
   product(id: ID!): Product
+  deprecatedProduct(sku: String!, package: String!): DeprecatedProduct @deprecated(reason: "Use product query instead")
 }
 
 extend type User @key(fields: "email") {

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -17,6 +17,7 @@ export const TESTS = [
   { assertion: "@key single", column: "@key (single)", fedVersion: 1, required: true },
   { assertion: "@key multiple", column: "@key (multi)", fedVersion: 1, required: false },
   { assertion: "@key composite", column: "@key (composite)", fedVersion: 1, required: false },
+  { assertion: "repeatable @key", column: "repeatable @key", fedVersion: 1, required: false },
   { assertion: "@requires", column: "@requires", fedVersion: 1, required: false },
   { assertion: "@provides", column: "@provides", fedVersion: 1, required: false },
   { assertion: "ftv1", column: "@ftv1", fedVersion: 1, required: false },

--- a/src/tests/inaccessible.test.ts
+++ b/src/tests/inaccessible.test.ts
@@ -1,4 +1,4 @@
-import { productsRequest, graphqlRequest, ROUTER_URL } from "../utils/client";
+import { productsRequest } from "../utils/client";
 import { stripIgnoredCharacters } from "graphql";
 
 describe("@inaccessible", () => {
@@ -7,9 +7,8 @@ describe("@inaccessible", () => {
       query: "query { _service { sdl } }",
     });
 
-    
     const { sdl } = response.data._service;
-    const normalizedSDL = stripIgnoredCharacters(sdl); 
+    const normalizedSDL = stripIgnoredCharacters(sdl);
     expect(normalizedSDL).not.toContain("@federation__inaccessible");
     expect(normalizedSDL).toContain("unit:String@inaccessible");
   });

--- a/supergraph.graphql
+++ b/supergraph.graphql
@@ -22,11 +22,27 @@ directive @link(url: String, as: String, for: link__Purpose, import: [link__Impo
 
 directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
+type CaseStudy
+  @join__type(graph: PRODUCTS)
+{
+  caseNumber: ID!
+  description: String
+}
+
 type DeliveryEstimates
   @join__type(graph: INVENTORY)
 {
   estimatedDelivery: String
   fastestDelivery: String
+}
+
+type DeprecatedProduct
+  @join__type(graph: PRODUCTS, key: "sku package")
+{
+  sku: String!
+  package: String!
+  reason: String
+  createdBy: User
 }
 
 scalar join__FieldSet
@@ -65,6 +81,7 @@ type Product
   variation: ProductVariation @join__field(graph: PRODUCTS)
   createdBy: User @join__field(graph: PRODUCTS, provides: "totalProductsCreated")
   notes: String @tag(name: "internal") @join__field(graph: PRODUCTS)
+  research: [ProductResearch!]! @join__field(graph: PRODUCTS)
 }
 
 type ProductDimension
@@ -74,6 +91,13 @@ type ProductDimension
   size: String
   weight: Float
   unit: String @inaccessible @join__field(graph: PRODUCTS)
+}
+
+type ProductResearch
+  @join__type(graph: PRODUCTS, key: "study { caseNumber }")
+{
+  study: CaseStudy!
+  outcome: String
 }
 
 type ProductVariation
@@ -88,6 +112,7 @@ type Query
   @join__type(graph: USERS)
 {
   product(id: ID!): Product @join__field(graph: PRODUCTS)
+  deprecatedProduct(sku: String!, package: String!): DeprecatedProduct @deprecated(reason: "Use product query instead") @join__field(graph: PRODUCTS)
 }
 
 type User


### PR DESCRIPTION
Update `product` subgraph with additional entites to separate testing for various `@key` test cases. Previously we were testing single entity that was supposed to define multiple `@key` directives. This was problematic as not all implementations support repeatable directives and we never checked whether given `@key` test case was actually present in the schema (test was executing `_entities` query only).

Schema changes (existing fields and types are omitted for clarity):

```graphql
type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }") {
  # new field
  research: [ProductResearch!]!
}

type DeprecatedProduct @key(fields: "sku package") {
  sku: String!
  package: String!
  reason: String
  createdBy: User
}

type ProductResearch @key(fields: "study { caseNumber }") {
  study: CaseStudy!
  outcome: String
}

type CaseStudy {
  caseNumber: ID!
  description: String
}

extend type Query {
  # new query
  deprecatedProduct(sku: String!, package: String!): DeprecatedProduct @deprecated(reason: "Use product query instead")
}
```

Update `@key` tests cases to verify:

* single field `@key` functionality against `User` type
* multiple field `@key` functionality against `DeprecatedProduct` type
* composite object `@key` functionality against `ProductResearch` type
* repeatable `@key` functionality against `Product` type (this test combines old tests into a single one)

Related Issues:

* resolves https://github.com/apollographql/apollo-federation-subgraph-compatibility/issues/144
* resolves https://github.com/apollographql/apollo-federation-subgraph-compatibility/issues/149