### PR TITLE
update apollo-server implementation to the latest schema

### DIFF
--- a/implementations/apollo-server/products.graphql
+++ b/implementations/apollo-server/products.graphql
@@ -1,6 +1,8 @@
 extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.0",
-        import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override", "@inaccessible", "@requires"])
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.0",
+    import: ["@extends", "@external", "@inaccessible", "@key", "@override", "@provides", "@requires", "@shareable", "@tag"]
+  )
 
 type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }") {
   id: ID!
@@ -10,6 +12,28 @@ type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku va
   dimensions: ProductDimension
   createdBy: User @provides(fields: "totalProductsCreated")
   notes: String @tag(name: "internal")
+  research: [ProductResearch!]!
+}
+
+type DeprecatedProduct @key(fields: "sku package") {
+  sku: String!
+  package: String!
+  reason: String
+  createdBy: User
+}
+
+type ProductVariation {
+  id: ID!
+}
+
+type ProductResearch @key(fields: "study { caseNumber }") {
+  study: CaseStudy!
+  outcome: String
+}
+
+type CaseStudy {
+  caseNumber: ID!
+  description: String
 }
 
 type ProductDimension @shareable {
@@ -18,15 +42,12 @@ type ProductDimension @shareable {
   unit: String @inaccessible
 }
 
-type ProductVariation {
-  id: ID!
-}
-
-type Query {
+extend type Query {
   product(id: ID!): Product
+  deprecatedProduct(sku: String!, package: String!): DeprecatedProduct @deprecated(reason: "Use product query instead")
 }
 
-type User @key(fields: "email") @extends {
+extend type User @key(fields: "email") {
   averageProductsCreatedPerYear: Int @requires(fields: "totalProductsCreated yearsOfEmployment")
   email: ID! @external
   name: String @override(from: "users")


### PR DESCRIPTION
Update `product` schema to allow for more granular testing of `@key` directive functionality.

Related issue:
* https://github.com/apollographql/apollo-federation-subgraph-compatibility/issues/166