### PR TITLE
relax federated SDL comparison logic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ function getFolderNamesFromPath(path: string) {
 }
 
 async function runDockerCompose(libraryName: string, librariesPath: string) {
-  console.log("Starting containers...");
+  console.log(`Starting containers for testing ${libraryName} implementation...`);
   const proc = execa("docker", [
     "compose",
     "-f",
@@ -53,7 +53,7 @@ async function runDockerCompose(libraryName: string, librariesPath: string) {
   }
 
   return async () => {
-    console.log("Stopping containers...");
+    console.log(`Stopping ${libraryName} and related containers...`);
     await execa("docker-compose", ["down", "--remove-orphans"]);
   };
 }

--- a/src/utils/schemaComparison.ts
+++ b/src/utils/schemaComparison.ts
@@ -187,7 +187,7 @@ export function compareSchemas(schemaToCompare: string): boolean {
   const expectedQueryDefinition = findObjectTypeExtensionDefinition(productsReferenceSchema, "Query") ?? findObjectTypeDefinition(productsReferenceSchema, "Query");
   const actualQueryDefinition = findObjectTypeExtensionDefinition(schemaDefinition, "Query") ?? findObjectTypeDefinition(schemaDefinition, "Query");
   const queryFields = actualQueryDefinition.fields.filter((field) => {
-    return !["_service", "_entities"].includes(field.name.value)
+    return ["product", "deprecatedProduct"].includes(field.name.value)
   });
   errors += compareTypeFields("Query", queryFields, expectedQueryDefinition.fields);
 


### PR DESCRIPTION
Previously we were verifying whether `Query` type implements the same queries as the expected schema (minus `_service` and `_entities` ones). Instead we should just verify whether target schemas implement the `product` and `deprecatedProduct` queries.