### PR TITLE
create separate workflows for each implementations

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,17 +2,20 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # - uses: actions/setup-node@v2
       #   with:
-      #     node-version: '14'
+      #     node-version: '16'
       #     check-latest: true
 
       #Setup project and package extension

--- a/.github/workflows/templates/test-subgraph-hosted.yaml.template
+++ b/.github/workflows/templates/test-subgraph-hosted.yaml.template
@@ -1,0 +1,36 @@
+name: <Implementation> Test
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    paths:
+      - 'implementations/<implementation>/**'
+
+jobs:
+  compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Setup Environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Compile supergraph
+        run: npm run setup
+      - name: Compatibility test
+        run: npm run test <implementation>
+        env:
+          DEBUG: docker,test
+          API_KEY_<IMPLEMENTATION>: ${{ secrets.API_KEY_<IMPLEMENTATION> }}
+          URL_<IMPLEMENTATION>: ${{ secrets.URL_<IMPLEMENTATION> }}
+      - name: Generate Results Summary
+        run: |
+          cat results.md
+          cat results.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/templates/test-subgraph-library.yaml.template
+++ b/.github/workflows/templates/test-subgraph-library.yaml.template
@@ -1,0 +1,14 @@
+name: <Implementation> Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/<implementation>/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "<implementation>"

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -32,9 +32,6 @@ jobs:
       matrix:
         name: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
     runs-on: ubuntu-latest
-    # uses: ./.github/workflows/test-subgraph.yaml
-    # with:
-    #   library: "${{ matrix.name }}"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -1,11 +1,15 @@
 name: Test
 
-on: 
+on:
   pull_request_target:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
+    paths:
+      - 'src/**'
+      - 'subgraphs/**'
+      - '*.json'
+      - '*.yaml'
+      - '*.graphql'
 
 jobs:
   build-matrix:
@@ -13,7 +17,7 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: generate matrix
@@ -28,10 +32,18 @@ jobs:
       matrix:
         name: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
     runs-on: ubuntu-latest
+    # uses: ./.github/workflows/test-subgraph.yaml
+    # with:
+    #   library: "${{ matrix.name }}"
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
       - run: npm install
       - run: npm run setup
       - run: npm run test ${{ matrix.name }}

--- a/.github/workflows/test-subgraph-absinthe-federation.yaml
+++ b/.github/workflows/test-subgraph-absinthe-federation.yaml
@@ -1,0 +1,14 @@
+name: Absinthe Federation Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/absinthe-federation/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "absinthe-federation"

--- a/.github/workflows/test-subgraph-apollo-server.yaml
+++ b/.github/workflows/test-subgraph-apollo-server.yaml
@@ -1,0 +1,14 @@
+name: Apollo Server Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/apollo-server/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "apollo-server"

--- a/.github/workflows/test-subgraph-appsync.yaml
+++ b/.github/workflows/test-subgraph-appsync.yaml
@@ -1,0 +1,36 @@
+name: AWS AppSync Test
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    paths:
+      - 'implementations/appsync/**'
+
+jobs:
+  compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Setup Environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Compile supergraph
+        run: npm run setup
+      - name: Compatibility test
+        run: npm run test appsync
+        env:
+          DEBUG: docker,test
+          API_KEY_APPSYNC: ${{ secrets.API_KEY_APPSYNC }}
+          URL_APPSYNC: ${{ secrets.URL_APPSYNC }}
+      - name: Generate Results Summary
+        run: |
+          cat results.md
+          cat results.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-subgraph-ariadne.yaml
+++ b/.github/workflows/test-subgraph-ariadne.yaml
@@ -1,0 +1,14 @@
+name: Ariadne Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/ariadne/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "ariadne"

--- a/.github/workflows/test-subgraph-async-graphql.yaml
+++ b/.github/workflows/test-subgraph-async-graphql.yaml
@@ -1,0 +1,14 @@
+name: Async GraphQL Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/async-graphql/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "async-graphql"

--- a/.github/workflows/test-subgraph-caliban.yaml
+++ b/.github/workflows/test-subgraph-caliban.yaml
@@ -1,0 +1,14 @@
+name: Caliban Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/caliban/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "caliban"

--- a/.github/workflows/test-subgraph-dgs.yaml
+++ b/.github/workflows/test-subgraph-dgs.yaml
@@ -1,0 +1,14 @@
+name: DGS Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/dgs/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "dgs"

--- a/.github/workflows/test-subgraph-express-graphql.yaml
+++ b/.github/workflows/test-subgraph-express-graphql.yaml
@@ -1,0 +1,14 @@
+name: Express GraphQL Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/express-graphql/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "express-graphql"

--- a/.github/workflows/test-subgraph-federation-jvm.yaml
+++ b/.github/workflows/test-subgraph-federation-jvm.yaml
@@ -1,0 +1,14 @@
+name: Federation JVM Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/federation-jvm/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "federation-jvm"

--- a/.github/workflows/test-subgraph-gqlgen.yaml
+++ b/.github/workflows/test-subgraph-gqlgen.yaml
@@ -1,0 +1,14 @@
+name: GQLGen Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/gqlgen/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "gqlgen"

--- a/.github/workflows/test-subgraph-graphene.yaml
+++ b/.github/workflows/test-subgraph-graphene.yaml
@@ -1,0 +1,14 @@
+name: Graphene Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/graphene/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "graphene"

--- a/.github/workflows/test-subgraph-graphql-dotnet.yaml
+++ b/.github/workflows/test-subgraph-graphql-dotnet.yaml
@@ -1,0 +1,14 @@
+name: GraphQL for .Net Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/graphql-dotnet/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "graphql-dotnet"

--- a/.github/workflows/test-subgraph-graphql-java-kickstart.yaml
+++ b/.github/workflows/test-subgraph-graphql-java-kickstart.yaml
@@ -1,0 +1,14 @@
+name: GraphQL Java Kickstart Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/graphql-java-kickstart/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "graphql-java-kickstart"

--- a/.github/workflows/test-subgraph-graphql-kotlin.yaml
+++ b/.github/workflows/test-subgraph-graphql-kotlin.yaml
@@ -1,0 +1,14 @@
+name: GraphQL Kotlin Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/graphql-kotlin/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "graphql-kotlin"

--- a/.github/workflows/test-subgraph-graphql-yoga.yaml
+++ b/.github/workflows/test-subgraph-graphql-yoga.yaml
@@ -1,0 +1,14 @@
+name: GraphQL Yoga Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/graphql-yoga/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "graphql-yoga"

--- a/.github/workflows/test-subgraph-hotchocolate.yaml
+++ b/.github/workflows/test-subgraph-hotchocolate.yaml
@@ -1,0 +1,14 @@
+name: HotChocolate Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/hotchocolate/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "hotchocolate"

--- a/.github/workflows/test-subgraph-lighthouse.yaml
+++ b/.github/workflows/test-subgraph-lighthouse.yaml
@@ -1,0 +1,14 @@
+name: Lighthouse Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/lighthouse/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "lighthouse"

--- a/.github/workflows/test-subgraph-mercurius.yaml
+++ b/.github/workflows/test-subgraph-mercurius.yaml
@@ -1,0 +1,14 @@
+name: Mercurius Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/mercurius/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "mercurius"

--- a/.github/workflows/test-subgraph-nestjs.yaml
+++ b/.github/workflows/test-subgraph-nestjs.yaml
@@ -1,0 +1,14 @@
+name: NestJS Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/nestjs/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "nestjs"

--- a/.github/workflows/test-subgraph-php.yaml
+++ b/.github/workflows/test-subgraph-php.yaml
@@ -1,0 +1,14 @@
+name: Apollo Federation PHP Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/php/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "php"

--- a/.github/workflows/test-subgraph-pothos.yaml
+++ b/.github/workflows/test-subgraph-pothos.yaml
@@ -1,0 +1,14 @@
+name: Pothos Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/pothos/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "pothos"

--- a/.github/workflows/test-subgraph-ruby.yaml
+++ b/.github/workflows/test-subgraph-ruby.yaml
@@ -1,0 +1,14 @@
+name: GraphQL Ruby Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/ruby/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "ruby"

--- a/.github/workflows/test-subgraph-stepzen.yaml
+++ b/.github/workflows/test-subgraph-stepzen.yaml
@@ -1,0 +1,35 @@
+name: StepZen Test
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    paths:
+      - 'implementations/stepzen/**'
+
+jobs:
+  compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Setup Environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Compile supergraph
+        run: npm run setup
+      - name: Compatibility test
+        run: npm run test stepzen
+        env:
+          DEBUG: docker,test
+          URL_STEPZEN: ${{ secrets.URL_STEPZEN }}
+      - name: Generate Results Summary
+        run: |
+          cat results.md
+          cat results.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-subgraph-strawberry-graphql.yaml
+++ b/.github/workflows/test-subgraph-strawberry-graphql.yaml
@@ -1,0 +1,14 @@
+name: Strawberry GraphQL Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'implementations/strawberry-graphql/**'
+
+jobs:
+  compatibility:
+    uses: ./.github/workflows/test-subgraph.yaml
+    with:
+      library: "strawberry-graphql"

--- a/.github/workflows/test-subgraph.yaml
+++ b/.github/workflows/test-subgraph.yaml
@@ -1,0 +1,32 @@
+name: Subgraph Test
+
+on:
+  workflow_call:
+    inputs:
+      library:
+        required: true
+        type: string
+
+jobs:
+  compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Setup Environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Compile supergraph
+        run: npm run setup
+      - name: Compatibility test
+        run: npm run test ${{ inputs.library }}
+        env:
+          DEBUG: docker,test
+      - name: Generate Results Summary
+        run: |
+          cat results.md
+          cat results.md >> $GITHUB_STEP_SUMMARY

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -44,6 +44,10 @@ implement to be used in the testing suite:
    should only affect the `products` service defined.
 5. Test only your library by running `npm run setup` and `npm run test {YOUR_IMPLEMENTATION_FOLDER_NAME}`
    and the results will be outputted to `results.md`
+6. Copy the `.github/workflows/templates/test-subgraph-library.yaml.template` and rename
+   it to include the name of your library under `.github/workflows/test-subgraph-<library>.yaml`
+   - This is a workflow that will be triggered for PRs opened against your implementation.
+   - Modify the template so it only triggers for your implementation.
 
 ## How can I have my hosted subgraph included in this?
 
@@ -82,6 +86,11 @@ compatibility tests will fail.**
    export URL_FOO=http://example.com
    npm run test foo
    ```
+
+6. Copy the `.github/workflows/templates/test-subgraph-hosted.yaml.template` and rename
+   it to include the name of your implementation under `.github/workflows/test-subgraph-<hosted>.yaml`
+   - This is a workflow that will be triggered for PRs opened against your implementation.
+   - Modify the template so it only triggers for your implementation.
 
 ### Expected Data Sets
 


### PR DESCRIPTION
With separate workflows, only modified subgraph implementation will be build on the PRs (vs current logic of building everything regardless specific implementation was changed or not).