### PR TITLE
build: use new GH action output env

### DIFF
--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: generate matrix
         id: matrix
         run: |
-          echo "::set-output name=matrix::$(ls implementations | jq -cnR '[inputs | select(. | test("^[a-z]"))]')"
+          echo "matrix=$(ls implementations | jq -cnR '[inputs | select(. | test("^[a-z]"))]')" >> $GITHUB_OUTPUT
 
   build:
     timeout-minutes: 60


### PR DESCRIPTION
`save-state` and `set-output` workflow commands are now deprecated.

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/