### PR TITLE
build: update action versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,10 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      # - uses: actions/setup-node@v2
-      #   with:
-      #     node-version: '16'
-      #     check-latest: true
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
 
       #Setup project and package extension
       - run: npm install
@@ -33,7 +32,7 @@ jobs:
         run: cat results.md > $GITHUB_STEP_SUMMARY
 
       - id: create-version
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         with:
           script: |
             const num = context.runNumber;
@@ -46,6 +45,7 @@ jobs:
             core.exportVariable('VERSION', version);
 
       #Create new release
+      # TODO this action is deprecated and using old version of node (12)
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -57,7 +57,8 @@ jobs:
           draft: false
           prerelease: false
 
-      #Upload Results to release0
+      #Upload Results to release
+      # TODO this action is deprecated and using old version of node (12)
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -40,7 +40,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: 'npm'
       - run: npm install
       - run: npm run setup

--- a/.github/workflows/test-subgraph.yaml
+++ b/.github/workflows/test-subgraph.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Environment
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: 'npm'
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
See: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/