### PR TITLE
Restrict files that are published to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,11 @@ tmp
 
 # exclude docs
 images
+
+.dockerignore
+.gitattributes
+.github
+.vscode
+
+jest.config.js
+tsconfig.json


### PR DESCRIPTION
Currently these files are all published to the registry in the tarball and don't need to be.

You can preview the list with `npm pack --dry-run`