### PR TITLE
Update package.json metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2021 Apollo Graph
+The MIT License (MIT)
+
+Copyright (c) 2022 Apollo Graph
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@apollo/federation-subgraph-compatibility",
   "version": "0.0.1",
+  "description": "A CLI tool for checking a subgraph's compatibility with a federated gateway",
   "workspaces": [
     "subgraphs/inventory",
     "subgraphs/users"
@@ -30,6 +31,12 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "author": "Apollo <packages@apollographql.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/apollographql/apollo-federation-subgraph-compatibility/issues"
+  },
+  "homepage": "https://github.com/apollographql/apollo-federation-subgraph-compatibility#readme",
   "dependencies": {
     "@apollo/rover": "^0.10.0",
     "commander": "^9.4.1",


### PR DESCRIPTION
This metadata is published to [npmjs](https://www.npmjs.com/package/@apollo/federation-subgraph-compatibility) whenever you publish a package.