### PR TITLE
fix: relative path and process exit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,5 @@ supergraph.yaml
 
 results*
 final_results.json
+
+packages/compatibility/products.graphql

--- a/.npmignore
+++ b/.npmignore
@@ -18,6 +18,7 @@ mkdocs.yml
 .prettierrc
 .prettierignore
 .vscode
+*.tsbuildinfo
 tsconfig.json
 
 simple-schema.apollo-workbench

--- a/implementations/_template_hosted_/products.graphql
+++ b/implementations/_template_hosted_/products.graphql
@@ -1,10 +1,23 @@
 extend schema
   @link(
-    url: "https://specs.apollo.dev/federation/v2.0",
-    import: ["@extends", "@external", "@inaccessible", "@key", "@override", "@provides", "@requires", "@shareable", "@tag"]
+    url: "https://specs.apollo.dev/federation/v2.0"
+    import: [
+      "@extends"
+      "@external"
+      "@inaccessible"
+      "@key"
+      "@override"
+      "@provides"
+      "@requires"
+      "@shareable"
+      "@tag"
+    ]
   )
 
-type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }") {
+type Product
+  @key(fields: "id")
+  @key(fields: "sku package")
+  @key(fields: "sku variation { id }") {
   id: ID!
   sku: String
   package: String
@@ -44,11 +57,13 @@ type ProductDimension @shareable {
 
 extend type Query {
   product(id: ID!): Product
-  deprecatedProduct(sku: String!, package: String!): DeprecatedProduct @deprecated(reason: "Use product query instead")
+  deprecatedProduct(sku: String!, package: String!): DeprecatedProduct
+    @deprecated(reason: "Use product query instead")
 }
 
 extend type User @key(fields: "email") {
-  averageProductsCreatedPerYear: Int @requires(fields: "totalProductsCreated yearsOfEmployment")
+  averageProductsCreatedPerYear: Int
+    @requires(fields: "totalProductsCreated yearsOfEmployment")
   email: ID! @external
   name: String @override(from: "users")
   totalProductsCreated: Int @external

--- a/implementations/_template_library_/products.graphql
+++ b/implementations/_template_library_/products.graphql
@@ -1,10 +1,23 @@
 extend schema
   @link(
-    url: "https://specs.apollo.dev/federation/v2.0",
-    import: ["@extends", "@external", "@inaccessible", "@key", "@override", "@provides", "@requires", "@shareable", "@tag"]
+    url: "https://specs.apollo.dev/federation/v2.0"
+    import: [
+      "@extends"
+      "@external"
+      "@inaccessible"
+      "@key"
+      "@override"
+      "@provides"
+      "@requires"
+      "@shareable"
+      "@tag"
+    ]
   )
 
-type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }") {
+type Product
+  @key(fields: "id")
+  @key(fields: "sku package")
+  @key(fields: "sku variation { id }") {
   id: ID!
   sku: String
   package: String
@@ -44,11 +57,13 @@ type ProductDimension @shareable {
 
 extend type Query {
   product(id: ID!): Product
-  deprecatedProduct(sku: String!, package: String!): DeprecatedProduct @deprecated(reason: "Use product query instead")
+  deprecatedProduct(sku: String!, package: String!): DeprecatedProduct
+    @deprecated(reason: "Use product query instead")
 }
 
 extend type User @key(fields: "email") {
-  averageProductsCreatedPerYear: Int @requires(fields: "totalProductsCreated yearsOfEmployment")
+  averageProductsCreatedPerYear: Int
+    @requires(fields: "totalProductsCreated yearsOfEmployment")
   email: ID! @external
   name: String @override(from: "users")
   totalProductsCreated: Int @external

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "packages/subgraphs/*"
   ],
   "scripts": {
-    "build": "tsc --build tsconfig.json && npm run package-subgraphs",
+    "build": "tsc --build tsconfig.json && npm run package",
     "clean": "rm -rf packages/*/dist packages/*/tsconfig.tsbuildinfo",
     "compatibility:report": "node packages/script/dist/generateReportCommand.js",
     "compatibility:test": "node packages/script/dist/compatibilityTestCommand.js",
     "lint": "eslint .",
-    "package-subgraphs": "concurrently \"npm:package-subgraphs:*\"",
+    "package": "cp implementations/_template_library_/products.graphql packages/compatibility && concurrently \"npm:package-subgraphs:*\"",
     "package-subgraphs:inventory": "ncc build packages/subgraphs/inventory/index.js --source-map --out packages/compatibility/dist/subgraphs/inventory && cp packages/subgraphs/inventory/Dockerfile packages/subgraphs/inventory/inventory.graphql packages/compatibility/dist/subgraphs/inventory",
     "package-subgraphs:users": "ncc build packages/subgraphs/users/index.js --source-map --out packages/compatibility/dist/subgraphs/users && cp packages/subgraphs/users/Dockerfile packages/subgraphs/users/users.graphql packages/compatibility/dist/subgraphs/users",
     "prettier-check": "prettier --check .",

--- a/packages/compatibility/src/compatibilityTest.ts
+++ b/packages/compatibility/src/compatibilityTest.ts
@@ -44,5 +44,4 @@ export async function compatibilityTest(
   logWithTimestamp('compatibility test complete');
   // print results to console
   logResults(testResults);
-  process.exit(0);
 }

--- a/packages/compatibility/src/utils/schemaComparison.ts
+++ b/packages/compatibility/src/utils/schemaComparison.ts
@@ -13,14 +13,9 @@ import {
 } from 'graphql';
 import { resolve } from 'path';
 
+// TODO -> this is not bundled in distribution!!!!!
 const productsRaw = readFileSync(
-  resolve(
-    __dirname,
-    '../../../..',
-    'implementations',
-    '_template_library_',
-    'products.graphql',
-  ),
+  resolve(__dirname, '../products.graphql'),
   'utf-8',
 );
 const productsReferenceSchema = parse(productsRaw);


### PR DESCRIPTION
Fix relative path of schema used for introspection comparison and remove `process.exit(0)` from the script (to allow action to run additional logic afterwards).