### PR TITLE
dropping fedReport script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -390,9 +390,9 @@
       }
     },
     "node_modules/@babel/core/node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -5787,9 +5787,9 @@
       "optional": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -8519,7 +8519,6 @@
         "debug": "^4.3.4"
       },
       "bin": {
-        "fedReport": "dist/generateReportCommand.js",
         "fedtest": "dist/compatibilityTestCommand.js"
       },
       "devDependencies": {
@@ -8849,9 +8848,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
         },
         "semver": {
           "version": "6.3.0",
@@ -12968,9 +12967,9 @@
       "optional": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"

--- a/packages/compatibility/src/utils/markdown.ts
+++ b/packages/compatibility/src/utils/markdown.ts
@@ -137,7 +137,7 @@ The following open-source GraphQL server libraries and other solutions support a
     let cell = '<table>';
     TESTS.forEach((test) => {
       if (test.fedVersion === fedVersion) {
-        cell += `<tr><th>${test.column}</th><td>${
+        cell += `<tr><th><code>${test.column}</code></th><td>${
           testResults[test.assertion]?.success
             ? '🟢'
             : test.required

--- a/packages/script/package.json
+++ b/packages/script/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.14",
   "description": "A CLI tool for checking a subgraph's compatibility with a federated gateway",
   "bin": {
-    "fedtest": "./dist/compatibilityTestCommand.js",
-    "fedReport": "./dist/generateReportCommand.js"
+    "fedtest": "./dist/compatibilityTestCommand.js"
   },
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",


### PR DESCRIPTION
NPX gets confused when multiple bin scripts are specified. Dropping `fedReport` from `bin` definitions as it should never be used outside of this testing repository.

This PR also fixes markdown by explicitly escaping directive names in the generated tables (as otherwise folks with those github handles get tagged constantly).