### PR TITLE
feat: add new --failOnWarning and --failOnRequired flags

### DIFF
--- a/packages/compatibility/src/compatibilityTest.ts
+++ b/packages/compatibility/src/compatibilityTest.ts
@@ -21,7 +21,7 @@ export async function compatibilityTest(
     // run tests
     const { assertionPassed } = await runJest();
     for (const { assertion, required } of TESTS) {
-      const testSuccessful = assertionPassed(assertion)
+      const testSuccessful = assertionPassed(assertion);
       testResults[assertion] = { success: testSuccessful };
 
       if (!testSuccessful) {

--- a/packages/compatibility/src/startSupergraph.ts
+++ b/packages/compatibility/src/startSupergraph.ts
@@ -21,6 +21,10 @@ export interface DockerConfig {
   port?: string;
   /** Report format */
   format: string;
+  /** Boolean flag to indicate whether any failing required test should fail the script. */
+  failOnRequired: boolean;
+  /** Boolean flag to indicate whether any failing test should fail the script. */
+  failOnWarning: boolean;
 }
 
 export interface Pm2Config {
@@ -33,6 +37,10 @@ export interface Pm2Config {
   configFile?: string;
   /** Report format */
   format: string;
+  /** Boolean flag to indicate whether any failing required test should fail the script. */
+  failOnRequired: boolean;
+  /** Boolean flag to indicate whether any failing test should fail the script. */
+  failOnWarning: boolean;
 }
 
 /**

--- a/packages/script/README.md
+++ b/packages/script/README.md
@@ -72,6 +72,8 @@ Options:
   --config <subgraph.config.js>  optional PM2 configuration file
   --debug                        debug mode with extra log info
   --endpoint <url>               subgraph endpoint
+  --failOnRequired               boolean flag to indicate whether any failing required test should fail the script.
+  --failOnWarning                boolean flag to indicate whether any failing test should fail the script.
   --format <json|markdown>       optional output file format (choices: "json", "markdown", default: "markdown")
   -h, --help                     display help for command
   --schema <schema.graphql>      optional path to schema file, if omitted composition will fallback to introspection
@@ -119,6 +121,8 @@ Start supergraph using Docker Compose
 Options:
   --compose <docker-compose.yaml>  Path to docker compose file
   --debug                          debug mode with extra log info
+  --failOnRequired                 boolean flag to indicate whether any failing required test should fail the script.
+  --failOnWarning                  boolean flag to indicate whether any failing test should fail the script.
   --format <json|markdown>         optional output file format (choices: "json", "markdown", default: "markdown")
   -h, --help                       display help for command
   --path <path>                    GraphQL endpoint path (default: "")

--- a/packages/script/src/compatibilityTestCommand.ts
+++ b/packages/script/src/compatibilityTestCommand.ts
@@ -26,6 +26,8 @@ function generateRuntimeConfig(
       path: options.path,
       port: options.port,
       format: options.format,
+      failOnRequired: options.failOnRequired,
+      failOnWarning: options.failOnWarning
     };
   } else {
     runtimeConfig = {
@@ -34,6 +36,8 @@ function generateRuntimeConfig(
       schemaFile: options.schema,
       configFile: options.config,
       format: options.format,
+      failOnRequired: options.failOnRequired,
+      failOnWarning: options.failOnWarning
     };
   }
   return runtimeConfig;
@@ -48,6 +52,8 @@ class CompatibilityTestCommand extends Command {
           .default('markdown'),
       )
       .option('--debug', 'debug mode with extra log info')
+      .option('--failOnRequired', 'boolean flag to indicate whether any failing required test should fail the script.')
+      .option('--failOnWarning', 'boolean flag to indicate whether any failing test should fail the script.')
       .showHelpAfterError()
       .configureHelp({ sortOptions: true });
   }
@@ -74,7 +80,11 @@ program
       debug.enable('debug,pm2,docker,rover,test');
     }
     let runtimeConfig = generateRuntimeConfig(TestRuntime.PM2, options);
-    compatibilityTest(runtimeConfig);
+    compatibilityTest(runtimeConfig).then(successful => {
+      if (!successful) {
+        process.exitCode = 1;
+      }
+    });
   })
   .configureHelp({ sortOptions: true });
 
@@ -94,7 +104,11 @@ program
       debug.enable('debug,pm2,docker,rover,test');
     }
     let runtimeConfig = generateRuntimeConfig(TestRuntime.DOCKER, options);
-    compatibilityTest(runtimeConfig);
+    compatibilityTest(runtimeConfig).then(successful => {
+      if (!successful) {
+        process.exitCode = 1;
+      }
+    });
   })
   .configureHelp({ sortOptions: true });
 

--- a/packages/script/src/compatibilityTestCommand.ts
+++ b/packages/script/src/compatibilityTestCommand.ts
@@ -27,7 +27,7 @@ function generateRuntimeConfig(
       port: options.port,
       format: options.format,
       failOnRequired: options.failOnRequired,
-      failOnWarning: options.failOnWarning
+      failOnWarning: options.failOnWarning,
     };
   } else {
     runtimeConfig = {
@@ -37,7 +37,7 @@ function generateRuntimeConfig(
       configFile: options.config,
       format: options.format,
       failOnRequired: options.failOnRequired,
-      failOnWarning: options.failOnWarning
+      failOnWarning: options.failOnWarning,
     };
   }
   return runtimeConfig;
@@ -52,8 +52,14 @@ class CompatibilityTestCommand extends Command {
           .default('markdown'),
       )
       .option('--debug', 'debug mode with extra log info')
-      .option('--failOnRequired', 'boolean flag to indicate whether any failing required test should fail the script.')
-      .option('--failOnWarning', 'boolean flag to indicate whether any failing test should fail the script.')
+      .option(
+        '--failOnRequired',
+        'boolean flag to indicate whether any failing required test should fail the script.',
+      )
+      .option(
+        '--failOnWarning',
+        'boolean flag to indicate whether any failing test should fail the script.',
+      )
       .showHelpAfterError()
       .configureHelp({ sortOptions: true });
   }
@@ -80,7 +86,7 @@ program
       debug.enable('debug,pm2,docker,rover,test');
     }
     let runtimeConfig = generateRuntimeConfig(TestRuntime.PM2, options);
-    compatibilityTest(runtimeConfig).then(successful => {
+    compatibilityTest(runtimeConfig).then((successful) => {
       if (!successful) {
         process.exitCode = 1;
       }
@@ -104,7 +110,7 @@ program
       debug.enable('debug,pm2,docker,rover,test');
     }
     let runtimeConfig = generateRuntimeConfig(TestRuntime.DOCKER, options);
-    compatibilityTest(runtimeConfig).then(successful => {
+    compatibilityTest(runtimeConfig).then((successful) => {
       if (!successful) {
         process.exitCode = 1;
       }


### PR DESCRIPTION
Add new flags to fail the compatibility script based on whether **any** test (`--failOnWarning`) failed or **any required** test (`--failOnRequired`) failed.