### PR TITLE
fix: normalize paths to POSIX format

### DIFF
--- a/packages/compatibility/src/composeSupergraph.ts
+++ b/packages/compatibility/src/composeSupergraph.ts
@@ -2,6 +2,7 @@ import execa from 'execa';
 import debug from 'debug';
 import { healthcheckRouter, healthcheck } from './utils/client';
 import { logWithTimestamp, writeableDebugStream } from './utils/logging';
+import { normalizePath } from './utils/path';
 import { resolve } from 'path';
 import { readFile, writeFile } from 'fs/promises';
 import { createWriteStream } from 'fs';
@@ -109,7 +110,7 @@ export async function composeSupergraph(
     'utf-8',
   );
   const supergraphConfig = template
-    .replaceAll('${DIST_DIR}', resolve(__dirname))
+    .replaceAll('${DIST_DIR}', normalizePath(resolve(__dirname)))
     .replace('${PORT}', port)
     .replace('${GRAPHQL_PATH}', graphQLEndpoint)
     .replace('${SCHEMA_FILE}', schemaFile);

--- a/packages/compatibility/src/startSupergraph.ts
+++ b/packages/compatibility/src/startSupergraph.ts
@@ -3,6 +3,7 @@ import debug from 'debug';
 import { logWithTimestamp, writeableDebugStream } from './utils/logging';
 import { composeDevSupergraph, composeSupergraph } from './composeSupergraph';
 import { healtcheckSupergraph } from './utils/client';
+import { normalizePath } from './utils/path';
 import { resolve } from 'path';
 import { readFile, writeFile } from 'fs/promises';
 
@@ -80,7 +81,7 @@ async function startSupergraphUsingPm2(config: Pm2Config) {
     );
     const supergraphConfig = template.replaceAll(
       '${DIST_DIR}',
-      resolve(__dirname),
+      normalizePath(resolve(__dirname)),
     );
     await writeFile('supergraph.config.js', supergraphConfig);
 
@@ -155,8 +156,8 @@ async function startSupergraphUsingDocker(config: DockerConfig) {
     'utf-8',
   );
   const supergraphConfig = template
-    .replaceAll('${SCRIPT_DIR}', resolve(__dirname, '..'))
-    .replaceAll('${DIST_DIR}', resolve(__dirname));
+    .replaceAll('${SCRIPT_DIR}', normalizePath(resolve(__dirname, '..')))
+    .replaceAll('${DIST_DIR}', normalizePath(resolve(__dirname)));
 
   await writeFile('supergraph-compose.yaml', supergraphConfig);
 

--- a/packages/compatibility/src/utils/path.ts
+++ b/packages/compatibility/src/utils/path.ts
@@ -1,0 +1,8 @@
+import path from 'path';
+
+/**
+ * Normalizes passed in path to ensure it is always in POSIX format.
+ */
+export function normalizePath(pathToNormalize: string): string {
+  return pathToNormalize.split(path.sep).join(path.posix.sep);
+}


### PR DESCRIPTION
Normalize script paths to use POSIX format to avoid broken paths on Windows.