### PR TITLE
build: update GH actions to use pull_request event

### DIFF
--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -1,42 +1,99 @@
 name: Comment on PR
 
 on:
-  workflow_call:
-    inputs:
-      libraryName:
-        type: string
-        required: false
-      resultsFile:
-        required: true
-        type: string
-    secrets:
-      token:
-        required: true
+  workflow_run:
+    workflows:
+      - "Test"
+      - "Absinthe Federation Test"
+      - "Apollo Server Test"
+      - "Ariadne Test"
+      - "AWS AppSync Test"
+      - "Caliban Test"
+      - "Dgraph Test"
+      - "DGS Test"
+      - "Express GraphQL Test"
+      - "Federation JVM Test"
+      - "GQLGen Test"
+      - "Graphene Test"
+      - "GraphQL for .Net Test"
+      - "GraphQL Go Test"
+      - "GraphQL Helix Test"
+      - "GraphQL Java Kickstart Test"
+      - "GraphQL Kotlin Test"
+      - "GraphQL Mesh Test"
+      - "GraphQL Yoga Test"
+      - "HotChocolate Test"
+      - "Lighthouse Test"
+      - "Mercurius Test"
+      - "NestJS (Code First) Test"
+      - "NestJS (SDL First) Test"
+      - "Apollo Federation PHP Test"
+      - "Pothos Test"
+      - "GraphQL Ruby Test"
+      - "Sangria Test"
+      - "StepZen Test"
+      - "Strawberry GraphQL Test"
+    types:
+      - completed
 
 jobs:
   comment:
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     steps:
-      - name: Download Results File
-        uses: actions/download-artifact@v3
+      - name: Download Artifacts
+        uses: actions/github-script@v6
+        id: download_artifacts
         with:
-          name: ${{ inputs.resultsFile }}
+          script: |
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{ github.event.workflow_run.id }},
+            });
+            var prArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var downloadPrArtifact = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: prArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(downloadPrArtifact.data));
+
+            var compatibilityResult = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name.startsWith("results") && artifact.name.endsWith(".md")
+            })[0];
+            var downloadResultsArtifact = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: compatibilityResult.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/results.zip', Buffer.from(downloadResultsArtifact.data));
+
+            core.setOutput('results_file_name', compatibilityResult.name);
+      - name: Unpack artifacts
+        run: |
+          unzip pr.zip
+          unzip results.zip
       - name: Comment on PR
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
-          github-token: ${{secrets.token}}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            const results = fs.readFileSync('${{ inputs.resultsFile }}', 'utf-8');
-            const libraryName = '${{ inputs.libraryName }}';
-            let commentTitle = 'Apollo Federation Subgraph Compatibility Results';
-            if (libraryName) {
-              commentTitle = `${libraryName} Compatibility Results`
-            }
-            const commentBody = `## ${commentTitle}\n${results}\n`;
+            var issue_number = Number(fs.readFileSync('./pr_info'));
+            const results = fs.readFileSync('${{ steps.download_artifacts.outputs.results_file_name }}', 'utf-8');
+            const commentBody = `## Apollo Federation Subgraph Compatibility Results\n${results}\n`;
             github.rest.issues.createComment({
-              issue_number: context.issue.number,
+              issue_number: issue_number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: commentBody

--- a/.github/workflows/save-pr-info.yaml
+++ b/.github/workflows/save-pr-info.yaml
@@ -1,0 +1,21 @@
+name: Save PR info
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  save-pr-info:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/pr_info
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr/
+          retention-days: 1

--- a/.github/workflows/templates/test-subgraph-hosted.yaml.template
+++ b/.github/workflows/templates/test-subgraph-hosted.yaml.template
@@ -17,13 +17,3 @@ jobs:
       # secrets are optional
       API_KEY: ${{ secrets.API_KEY_<implementation> }}
       TEST_URL: ${{ secrets.URL_<implementation> }}
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      # display name for library, e.g. Apollo Server
-      libraryName: '<Implementation Name>'
-      resultsFile: "results-<implementation>.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/templates/test-subgraph-library.yaml.template
+++ b/.github/workflows/templates/test-subgraph-library.yaml.template
@@ -13,13 +13,3 @@ jobs:
     with:
       # should match folder name
       library: "<implementation>"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      # display name for library, e.g. Apollo Server
-      libraryName: '<Implementation Name>'
-      resultsFile: "results-<implementation>.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -1,7 +1,7 @@
 name: Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -89,12 +89,3 @@ jobs:
           name: results.md
           path: ./results.md
           retention-days: 7
-
-  pr-comment:
-    needs: report
-    uses: ./.github/workflows/comment.yaml
-    if: ${{ github.event_name == 'pull_request_target' }}
-    with:
-      resultsFile: "results.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-absinthe-federation.yaml
+++ b/.github/workflows/test-subgraph-absinthe-federation.yaml
@@ -1,7 +1,7 @@
 name: Absinthe Federation Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "absinthe-federation"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'Absinthe Federation'
-      resultsFile: "results-absinthe-federation.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-apollo-server.yaml
+++ b/.github/workflows/test-subgraph-apollo-server.yaml
@@ -1,7 +1,7 @@
 name: Apollo Server Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "apollo-server"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'Apollo Server'
-      resultsFile: "results-apollo-server.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-appsync.yaml
+++ b/.github/workflows/test-subgraph-appsync.yaml
@@ -12,15 +12,7 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "appsync"
+      fork: true
     secrets:
       API_KEY: ${{ secrets.API_KEY_APPSYNC }}
       TEST_URL: ${{ secrets.URL_APPSYNC }}
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'AWS AppSync'
-      resultsFile: "results-appsync.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-ariadne.yaml
+++ b/.github/workflows/test-subgraph-ariadne.yaml
@@ -1,7 +1,7 @@
 name: Ariadne Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "ariadne"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'Ariadne'
-      resultsFile: "results-ariadne.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-async-graphql.yaml
+++ b/.github/workflows/test-subgraph-async-graphql.yaml
@@ -1,7 +1,7 @@
 name: Async GraphQL Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "async-graphql"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'Async GraphQL'
-      resultsFile: "results-async-graphql.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-caliban.yaml
+++ b/.github/workflows/test-subgraph-caliban.yaml
@@ -1,7 +1,7 @@
 name: Caliban Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "caliban"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'Caliban'
-      resultsFile: "results-caliban.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-dgraph.yaml
+++ b/.github/workflows/test-subgraph-dgraph.yaml
@@ -1,7 +1,7 @@
 name: Dgraph Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "dgraph"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'Dgraph'
-      resultsFile: "results-dgraph.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-dgs.yaml
+++ b/.github/workflows/test-subgraph-dgs.yaml
@@ -1,7 +1,7 @@
 name: DGS Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "dgs"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'DGS Framework'
-      resultsFile: "results-dgs.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-express-graphql.yaml
+++ b/.github/workflows/test-subgraph-express-graphql.yaml
@@ -1,7 +1,7 @@
 name: Express GraphQL Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "express-graphql"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'Express GraphQL'
-      resultsFile: "results-express-graphql.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-federation-jvm.yaml
+++ b/.github/workflows/test-subgraph-federation-jvm.yaml
@@ -1,7 +1,7 @@
 name: Federation JVM Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "federation-jvm"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'Federation JVM'
-      resultsFile: "results-federation-jvm.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-gqlgen.yaml
+++ b/.github/workflows/test-subgraph-gqlgen.yaml
@@ -1,7 +1,7 @@
 name: GQLGen Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "gqlgen"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'gqlgen'
-      resultsFile: "results-gqlgen.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-graphene.yaml
+++ b/.github/workflows/test-subgraph-graphene.yaml
@@ -1,7 +1,7 @@
 name: Graphene Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "graphene"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'Graphene'
-      resultsFile: "results-graphene.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-graphql-dotnet.yaml
+++ b/.github/workflows/test-subgraph-graphql-dotnet.yaml
@@ -1,7 +1,7 @@
 name: GraphQL for .Net Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "graphql-dotnet"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'GraphQL for .NET'
-      resultsFile: "results-graphql-dotnet.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-graphql-go.yaml
+++ b/.github/workflows/test-subgraph-graphql-go.yaml
@@ -1,7 +1,7 @@
 name: GraphQL Go Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "graphql-go"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'GraphQL Go'
-      resultsFile: "results-graphql-go.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-graphql-helix.yaml
+++ b/.github/workflows/test-subgraph-graphql-helix.yaml
@@ -1,7 +1,7 @@
 name: GraphQL Helix Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "helix"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'GraphQL Helix'
-      resultsFile: "results-helix.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-graphql-java-kickstart.yaml
+++ b/.github/workflows/test-subgraph-graphql-java-kickstart.yaml
@@ -1,7 +1,7 @@
 name: GraphQL Java Kickstart Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "graphql-java-kickstart"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'GraphQL Java Kickstart'
-      resultsFile: "results-graphql-java-kickstart.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-graphql-kotlin.yaml
+++ b/.github/workflows/test-subgraph-graphql-kotlin.yaml
@@ -1,7 +1,7 @@
 name: GraphQL Kotlin Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "graphql-kotlin"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'GraphQL Kotlin'
-      resultsFile: "results-graphql-kotlin.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-graphql-mesh.yaml
+++ b/.github/workflows/test-subgraph-graphql-mesh.yaml
@@ -1,7 +1,7 @@
 name: GraphQL Mesh Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "graphql-mesh"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'GraphQL Mesh'
-      resultsFile: "results-graphql-mesh.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-graphql-yoga.yaml
+++ b/.github/workflows/test-subgraph-graphql-yoga.yaml
@@ -1,7 +1,7 @@
 name: GraphQL Yoga Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "graphql-yoga"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'GraphQL Yoga'
-      resultsFile: "results-graphql-yoga.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-hotchocolate.yaml
+++ b/.github/workflows/test-subgraph-hotchocolate.yaml
@@ -1,7 +1,7 @@
 name: HotChocolate Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "hotchocolate"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'HotChocolate'
-      resultsFile: "results-hotchocolate.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-lighthouse.yaml
+++ b/.github/workflows/test-subgraph-lighthouse.yaml
@@ -1,7 +1,7 @@
 name: Lighthouse Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "lighthouse"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'Lighthouse'
-      resultsFile: "results-lighthouse.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-mercurius.yaml
+++ b/.github/workflows/test-subgraph-mercurius.yaml
@@ -1,7 +1,7 @@
 name: Mercurius Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "mercurius"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'Mercurius'
-      resultsFile: "results-mercurius.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-nestjs_code.yaml
+++ b/.github/workflows/test-subgraph-nestjs_code.yaml
@@ -1,7 +1,7 @@
 name: NestJS (Code First) Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "nestjs-code-first"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'Nest JS (Code First)'
-      resultsFile: "results-nestjs-code-first.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-nestjs_sdl.yaml
+++ b/.github/workflows/test-subgraph-nestjs_sdl.yaml
@@ -1,7 +1,7 @@
 name: NestJS (SDL First) Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "nestjs"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'Nest JS (SDL First)'
-      resultsFile: "results-nestjs.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-php.yaml
+++ b/.github/workflows/test-subgraph-php.yaml
@@ -1,7 +1,7 @@
 name: Apollo Federation PHP Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "php"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'Federation PHP'
-      resultsFile: "results-php.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-pothos.yaml
+++ b/.github/workflows/test-subgraph-pothos.yaml
@@ -1,7 +1,7 @@
 name: Pothos Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "pothos"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'Pothos GraphQL'
-      resultsFile: "results-pothos.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-ruby.yaml
+++ b/.github/workflows/test-subgraph-ruby.yaml
@@ -1,7 +1,7 @@
 name: GraphQL Ruby Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "ruby"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'GraphQL Ruby'
-      resultsFile: "results-ruby.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-sangria.yaml
+++ b/.github/workflows/test-subgraph-sangria.yaml
@@ -1,7 +1,7 @@
 name: Sangria Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "sangria"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'Sangria'
-      resultsFile: "results-sangria.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-stepzen.yaml
+++ b/.github/workflows/test-subgraph-stepzen.yaml
@@ -12,14 +12,6 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "stepzen"
+      fork: true
     secrets:
       TEST_URL: ${{ secrets.URL_STEPZEN }}
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'StepZen'
-      resultsFile: "results-stepzen.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph-strawberry-graphql.yaml
+++ b/.github/workflows/test-subgraph-strawberry-graphql.yaml
@@ -1,7 +1,7 @@
 name: Strawberry GraphQL Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
@@ -12,12 +12,3 @@ jobs:
     uses: ./.github/workflows/test-subgraph.yaml
     with:
       library: "strawberry-graphql"
-
-  pr-comment:
-    needs: compatibility
-    uses: ./.github/workflows/comment.yaml
-    with:
-      libraryName: 'Strawberry GraphQL'
-      resultsFile: "results-strawberry-graphql.md"
-    secrets:
-      token: ${{ secrets.COMMENT_TOKEN }}

--- a/.github/workflows/test-subgraph.yaml
+++ b/.github/workflows/test-subgraph.yaml
@@ -9,6 +9,9 @@ on:
       format:
         default: markdown
         type: string
+      fork:
+        default: false
+        type: boolean
     secrets:
       TEST_URL:
         required: false
@@ -22,7 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
+        if: ${{ inputs.fork }} == false
         uses: actions/checkout@v3
+      - name: Checkout Repository (fork mode)
+        if: ${{ inputs.fork }} == true
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup Environment
         uses: actions/setup-node@v3
         with:

--- a/SUBGRAPH_GUIDE.md
+++ b/SUBGRAPH_GUIDE.md
@@ -48,6 +48,8 @@ implement to be used in the testing suite:
    it to include the name of your library under `.github/workflows/test-subgraph-<library>.yaml`
    - This is a workflow that will be triggered for PRs opened against your implementation.
    - Modify the template so it only triggers for your implementation.
+7. Update `.github/workflows/comment.yaml` workflow to include name of your newly created workflow (
+   this will enable automatic compatibility comments on PRs against your implementation).
 
 ## How can I have my hosted subgraph included in this?
 
@@ -91,6 +93,8 @@ compatibility tests will fail.**
    it to include the name of your implementation under `.github/workflows/test-subgraph-<hosted>.yaml`
    - This is a workflow that will be triggered for PRs opened against your implementation.
    - Modify the template so it only triggers for your implementation.
+7. Update `.github/workflows/comment.yaml` workflow to include name of your newly created workflow (
+   this will enable automatic compatibility comments on PRs against your implementation).
 
 ### Expected Data Sets
 


### PR DESCRIPTION
We needed custom GH token in order to be able to comment on PRs from forked repos (default GH token only allows read access from forked PRs). In order to use the secret we also had to switch to `pull_request_target` event.... but I forgot to update the checkout logic to account for forked PRs. As a result PR checks were executing against `main` codebase and were not verifying PR changes.

Instead of making all PR checks run using `pull_request_target', I've refactored workflows to no longer need to share GH token secret for comments. Comment workflow will now trigger upon successful run of a PR workflow (either specific implementation or test of all implementations).

Resolves: https://github.com/apollographql/apollo-federation-subgraph-compatibility/issues/343