### PR TITLE
update tests to include federation v2.3 compatibility

### DIFF
--- a/implementations/_template_hosted_/products.graphql
+++ b/implementations/_template_hosted_/products.graphql
@@ -1,11 +1,13 @@
 extend schema
   @link(
-    url: "https://specs.apollo.dev/federation/v2.0"
+    url: "https://specs.apollo.dev/federation/v2.3"
     import: [
+      "@composeDirective"
       "@extends"
       "@external"
-      "@inaccessible"
       "@key"
+      "@inaccessible"
+      "@interfaceObject"
       "@override"
       "@provides"
       "@requires"
@@ -13,8 +15,13 @@ extend schema
       "@tag"
     ]
   )
+  @link(url: "https://myspecs.dev/myCustomDirective/v1.0", import: ["@custom"])
+  @composeDirective(name: "@custom")
+
+directive @custom on OBJECT
 
 type Product
+  @custom
   @key(fields: "id")
   @key(fields: "sku package")
   @key(fields: "sku variation { id }") {
@@ -68,4 +75,9 @@ extend type User @key(fields: "email") {
   name: String @override(from: "users")
   totalProductsCreated: Int @external
   yearsOfEmployment: Int! @external
+}
+
+type Inventory @interfaceObject @key(fields: "id") {
+  id: ID!
+  deprecatedProducts: [DeprecatedProduct!]!
 }

--- a/implementations/_template_library_/products.graphql
+++ b/implementations/_template_library_/products.graphql
@@ -1,11 +1,13 @@
 extend schema
   @link(
-    url: "https://specs.apollo.dev/federation/v2.0"
+    url: "https://specs.apollo.dev/federation/v2.3"
     import: [
+      "@composeDirective"
       "@extends"
       "@external"
-      "@inaccessible"
       "@key"
+      "@inaccessible"
+      "@interfaceObject"
       "@override"
       "@provides"
       "@requires"
@@ -13,8 +15,13 @@ extend schema
       "@tag"
     ]
   )
+  @link(url: "https://myspecs.dev/myCustomDirective/v1.0", import: ["@custom"])
+  @composeDirective(name: "@custom")
+
+directive @custom on OBJECT
 
 type Product
+  @custom
   @key(fields: "id")
   @key(fields: "sku package")
   @key(fields: "sku variation { id }") {
@@ -68,4 +75,9 @@ extend type User @key(fields: "email") {
   name: String @override(from: "users")
   totalProductsCreated: Int @external
   yearsOfEmployment: Int! @external
+}
+
+type Inventory @interfaceObject @key(fields: "id") {
+  id: ID!
+  deprecatedProducts: [DeprecatedProduct!]!
 }

--- a/implementations/apollo-server/index.js
+++ b/implementations/apollo-server/index.js
@@ -49,6 +49,11 @@ const user = {
   totalProductsCreated: 1337
 };
 
+const inventory = {
+  id: "apollo-oss",
+  deprecatedProducts: [deprecatedProduct]
+}
+
 const sdl = readFileSync('products.graphql', 'utf-8');
 
 const typeDefs = gql(sdl);
@@ -144,6 +149,16 @@ const resolvers = {
           user.yearsOfEmployment = reference.yearsOfEmployment;
         }
         return user;
+      } else {
+        return null;
+      }
+    }
+  },
+  Inventory: {
+    /** @type {(reference: any) => any} */
+    __resolveReference: (reference) => {
+      if (inventory.id === reference.id) {
+        return inventory;
       } else {
         return null;
       }

--- a/implementations/apollo-server/products.graphql
+++ b/implementations/apollo-server/products.graphql
@@ -1,10 +1,14 @@
 extend schema
   @link(
-    url: "https://specs.apollo.dev/federation/v2.0",
-    import: ["@extends", "@external", "@inaccessible", "@key", "@override", "@provides", "@requires", "@shareable", "@tag"]
+    url: "https://specs.apollo.dev/federation/v2.3",
+    import: ["@composeDirective", "@extends", "@external", "@key", "@inaccessible", "@interfaceObject", "@override", "@provides", "@requires", "@shareable", "@tag"]
   )
+  @link(url: "https://myspecs.dev/myCustomDirective/v1.0", import: ["@custom"])
+  @composeDirective(name: "@custom")
 
-type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }") {
+directive @custom on OBJECT
+
+type Product @custom @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }") {
   id: ID!
   sku: String
   package: String
@@ -53,4 +57,9 @@ extend type User @key(fields: "email") {
   name: String @override(from: "users")
   totalProductsCreated: Int @external
   yearsOfEmployment: Int! @external
+}
+
+type Inventory @interfaceObject @key(fields: "id") {
+  id: ID!
+  deprecatedProducts: [DeprecatedProduct!]!
 }

--- a/packages/compatibility/src/composeSupergraph.ts
+++ b/packages/compatibility/src/composeSupergraph.ts
@@ -127,7 +127,11 @@ export async function composeSupergraph(
       '--config',
       'supergraph-config.yaml',
     ],
-    { env: { APOLLO_ELV2_LICENSE: 'accept' } },
+    {
+      env: {
+        APOLLO_ELV2_LICENSE: 'accept',
+      },
+    },
   );
   composeProcess.stdout.pipe(createWriteStream('supergraph.graphql'));
   composeProcess.stderr.pipe(writeableDebugStream(roverDebug));

--- a/packages/compatibility/src/composeSupergraph.ts
+++ b/packages/compatibility/src/composeSupergraph.ts
@@ -111,7 +111,7 @@ export async function composeSupergraph(
     'utf-8',
   );
   const supergraphConfig = template
-    .replace('${COMPOSITION_VERSION', COMPOSITION_VERSION)
+    .replace('${COMPOSITION_VERSION}', COMPOSITION_VERSION)
     .replaceAll('${DIST_DIR}', normalizePath(resolve(__dirname)))
     .replace('${PORT}', port)
     .replace('${GRAPHQL_PATH}', graphQLEndpoint)

--- a/packages/compatibility/src/composeSupergraph.ts
+++ b/packages/compatibility/src/composeSupergraph.ts
@@ -7,6 +7,7 @@ import { resolve } from 'path';
 import { readFile, writeFile } from 'fs/promises';
 import { createWriteStream } from 'fs';
 
+const COMPOSITION_VERSION = process.env['APOLLO_ROVER_DEV_COMPOSITION_VERSION'] ?? '2.3.1';
 const roverDebug = debug('rover');
 
 /**
@@ -78,7 +79,7 @@ async function composeDevSubgraph(
       params.push('--schema', schemaFile);
     }
 
-    const proc = execa('pm2', params);
+    const proc = execa('pm2', params, { env: { APOLLO_ROVER_DEV_COMPOSITION_VERSION: `v${COMPOSITION_VERSION}` } });
     proc.stdout.pipe(writeableDebugStream(roverDebug));
     proc.stderr.pipe(writeableDebugStream(roverDebug));
 
@@ -110,6 +111,7 @@ export async function composeSupergraph(
     'utf-8',
   );
   const supergraphConfig = template
+    .replace('${COMPOSITION_VERSION', COMPOSITION_VERSION)
     .replaceAll('${DIST_DIR}', normalizePath(resolve(__dirname)))
     .replace('${PORT}', port)
     .replace('${GRAPHQL_PATH}', graphQLEndpoint)

--- a/packages/compatibility/src/testRunner.ts
+++ b/packages/compatibility/src/testRunner.ts
@@ -74,6 +74,18 @@ export const TESTS = [
     fedVersion: 2,
     required: false,
   },
+  {
+    assertion: '@composeDirective',
+    column: '@composeDirective',
+    fedVersion: 2,
+    required: false,
+  },
+  {
+    assertion: '@interfaceObject',
+    column: '@interfaceObject',
+    fedVersion: 2,
+    required: false,
+  },
 ];
 
 export async function runJest(productsUrl: string): Promise<JestResults> {

--- a/packages/compatibility/src/tests/composeDirective.test.ts
+++ b/packages/compatibility/src/tests/composeDirective.test.ts
@@ -1,0 +1,50 @@
+import { stripIgnoredCharacters } from 'graphql';
+import { productsRequest } from '../utils/client';
+
+test('@composeDirective', async () => {
+  const serviceSDLQuery = await productsRequest({
+    query: 'query { _service { sdl } }',
+  });
+
+  const { sdl } = serviceSDLQuery.data._service;
+  const normalizedSDL = stripIgnoredCharacters(sdl);
+
+  // schema contains @link import of new composed directive
+  const linksRegex = /@link\(([\s\S]+?)\)/g;
+  expect(linksRegex.test(normalizedSDL)).toBe(true);
+  normalizedSDL.match(linksRegex).forEach((element) => {
+    const urlRegex = /url:(\".+?\")/;
+    if (urlRegex.test(element)) {
+      const linkUrl = JSON.parse(element.match(urlRegex)[1]);
+      const linkUrlSpecVersionRegex =
+        /https:\/\/myspecs.dev\/myCustomDirective\/v(.+)/;
+      // only verify @composeDirective spec @links
+      if (linkUrlSpecVersionRegex.test(linkUrl)) {
+        const linkImportsRegex = /import:\[(.+?)\]/;
+        if (linkImportsRegex.test(element)) {
+          // verify federation imports
+          const expected = ['@custom'];
+
+          const linkImportsMatch = element.match(linkImportsRegex);
+          const linkImports = linkImportsMatch[1].split(' ');
+          linkImports.forEach((importedElement) => {
+            if (!expected.includes(importedElement.replaceAll('"', ''))) {
+              expect('').toBe('unexpected @composeDirective import ${element}');
+            }
+          });
+        }
+      }
+    }
+  });
+
+  // @composeDirective is applied on schema
+  expect(normalizedSDL).toMatch(
+    /schema.*(@composeDirective|@federation__composeDirective)\(name:.*"@custom"\)/,
+  );
+
+  // schema contains @custom directive definition
+  expect(normalizedSDL).toMatch(/directive.*@custom on OBJECT/);
+
+  // @custom directive is applied on Product type
+  expect(normalizedSDL).toMatch(/type Product.*@custom.*\{/);
+});

--- a/packages/compatibility/src/tests/interfaceObject.test.ts
+++ b/packages/compatibility/src/tests/interfaceObject.test.ts
@@ -1,0 +1,40 @@
+import { stripIgnoredCharacters } from 'graphql';
+import { productsRequest, routerRequest } from '../utils/client';
+
+describe('@interfaceObject', () => {
+  test('verifies schema contains entity type marked as @interfaceObject', async () => {
+    const serviceSDLQuery = await productsRequest({
+      query: 'query { _service { sdl } }',
+    });
+
+    const { sdl } = serviceSDLQuery.data._service;
+    const normalizedSDL = stripIgnoredCharacters(sdl);
+    expect(normalizedSDL).toMatch(
+      /type Inventory.*(@interfaceObject|@federation__interfaceObject)/,
+    );
+    expect(normalizedSDL).toMatch(
+      /type Inventory.*(@key|@federation__key)\(fields:"id"( resolvable:true)?\)/,
+    );
+  });
+
+  test('verifies @interfaceObject entity returns new fields', async () => {
+    const resp = await routerRequest({
+      query: `query ($id: ID!) { inventory(id: $id) { deprecatedProducts { sku reason } } }`,
+      variables: { id: 'apollo-oss' },
+    });
+
+    expect(resp).not.toHaveProperty('errors');
+    expect(resp).toMatchObject({
+      data: {
+        inventory: {
+          deprecatedProducts: [
+            {
+              sku: 'apollo-federation-v1',
+              reason: 'Migrate to Federation V2',
+            },
+          ],
+        },
+      },
+    });
+  });
+});

--- a/packages/compatibility/src/tests/link.test.ts
+++ b/packages/compatibility/src/tests/link.test.ts
@@ -33,7 +33,7 @@ test('@link', async () => {
 
         const federationVersion = linkUrl.match(linkUrlSpecVersionRegex)[1];
         // only federation v2.0 and v2.1 are supported
-        expect(federationVersion).toMatch(/2\.0|2\.1/);
+        expect(federationVersion).toMatch(/2\.0|2\.1|2\.2|2\.3/);
 
         const linkImportsRegex = /import:\[(.+?)\]/;
         if (linkImportsRegex.test(element)) {
@@ -43,6 +43,7 @@ test('@link', async () => {
             '@extends',
             '@external',
             '@inaccessible',
+            '@interfaceObject',
             '@key',
             '@override',
             '@provides',

--- a/packages/compatibility/supergraph-config.yaml.template
+++ b/packages/compatibility/supergraph-config.yaml.template
@@ -1,4 +1,4 @@
-federation_version: =2.3.1
+federation_version: =${COMPOSITION_VERSION}
 subgraphs:
   inventory:
     routing_url: http://inventory:4003

--- a/packages/compatibility/supergraph-config.yaml.template
+++ b/packages/compatibility/supergraph-config.yaml.template
@@ -1,4 +1,4 @@
-federation_version: 2
+federation_version: =2.3.1
 subgraphs:
   inventory:
     routing_url: http://inventory:4003

--- a/packages/subgraphs/inventory/index.js
+++ b/packages/subgraphs/inventory/index.js
@@ -8,23 +8,33 @@ import { resolve } from 'path';
 
 const serverPort = parseInt(process.env.INVENTORY_PORT || '') || 4003;
 
-class DeliveryEstimates {
-  /** @type {string} */
-  estimatedDelivery;
-  /** @type {string} */
-  fastestDelivery;
+const deliveryEstimate = {
+  estimatedDelivery: '5/1/2019',
+  fastestDelivery: '5/1/2019',
+};
 
-  constructor() {
-    this.estimatedDelivery = '5/1/2019';
-    this.fastestDelivery = '5/1/2019';
-  }
-}
+const inventory = [
+  {
+    id: 'apollo-oss',
+    products: [
+      {
+        id: 'apollo-federation',
+      },
+    ],
+  },
+];
 
 const typeDefs = gql(
   readFileSync(resolve(__dirname, 'inventory.graphql'), 'utf-8'),
 );
 
 const resolvers = {
+  Query: {
+    /** @type {(_: any, args: any, context: any) => any} */
+    inventory: (_, args, context) => {
+      return inventory.find((i) => i.id == args.id);
+    },
+  },
   Product: {
     /** @type {(product: import('./typings').ProductReference, args: any, context: any) => any} */
     delivery: (product, args, context) => {
@@ -38,7 +48,17 @@ const resolvers = {
       if (args.zip != '94111')
         throw new GraphQLError("product.delivery input zip was not '94111'");
 
-      return new DeliveryEstimates();
+      return deliveryEstimate;
+    },
+  },
+  Inventory: {
+    /** @type {(inv: any, contextValue: any, info: any) => any} */
+    __resolveType(inv, contextValue, info) {
+      // Only Author has a name field
+      if (inv.id === 'apollo-oss') {
+        return 'OpenSourceInventory';
+      }
+      return null; // GraphQLError is thrown
     },
   },
 };

--- a/packages/subgraphs/inventory/inventory.graphql
+++ b/packages/subgraphs/inventory/inventory.graphql
@@ -1,6 +1,6 @@
 extend schema
   @link(
-    url: "https://specs.apollo.dev/federation/v2.0"
+    url: "https://specs.apollo.dev/federation/v2.3"
     import: [
       "@key"
       "@requires"
@@ -26,4 +26,18 @@ type ProductDimension @shareable {
 type DeliveryEstimates {
   estimatedDelivery: String
   fastestDelivery: String
+}
+
+interface Inventory @key(fields: "id") {
+  id: ID!
+  products: [Product!]!
+}
+
+type OpenSourceInventory implements Inventory @key(fields: "id") {
+  id: ID!
+  products: [Product!]!
+}
+
+type Query {
+  inventory(id: ID!): Inventory
 }

--- a/packages/subgraphs/users/users.graphql
+++ b/packages/subgraphs/users/users.graphql
@@ -1,6 +1,12 @@
+extend schema
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.3"
+    import: ["@key", "@shareable"]
+  )
+
 type User @key(fields: "email") {
   email: ID!
   name: String
-  totalProductsCreated: Int
+  totalProductsCreated: Int @shareable
   yearsOfEmployment: Int!
 }


### PR DESCRIPTION
Adds tests for `@composeDirective` (fed v2.1) and `@interfaceObject` (fed v2.3).

Schema changes:
* update `@link` federation spec to v2.3 and add imports for `@composeDirective` and `@interfaceObject`
```graphql
extend schema
  @link(
    url: "https://specs.apollo.dev/federation/v2.3",
    import: [
      "@composeDirective",
      "@extends",
      "@external",
      "@inaccessible",
      "@interfaceObject",
      "@key",
      "@override",
      "@provides",
      "@requires",
      "@shareable",
      "@tag"
    ]
  )
```

* apply `@link` to newly composed directive and `@composeDirective` on schema object (federation link import omitted for clarity)
```graphql
extend schema
  @link(url: "https://myspecs.dev/myCustomDirective/v1.0", import: ["@custom")
  @composeDirective(name: "@custom")
```

* new `@custom` directive definition

```graphql
directive @custom on OBJECT
```

* apply `@custom` directive on `Product` type (other directives/fields omitted for clarity)

```graphql
type Product @custom ... { ... }
```

* declare new `@interfaceObject` type

```graphql
type Inventory @interfaceObject @key(fields: "id") {
  id: ID!
  deprecatedProducts: [DeprecatedProduct!]!
}
```

expected data set (deprecatedProduct is the existing object)
```js
const inventory = {
  id: "apollo-oss",
  deprecatedProducts: [deprecatedProduct]
}
```

---
Resolves:
* https://github.com/apollographql/apollo-federation-subgraph-compatibility/issues/175
* https://github.com/apollographql/apollo-federation-subgraph-compatibility/issues/344