### PR TITLE
fix: update test-all workflow to look for correct event

### DIFF
--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -91,7 +91,7 @@ jobs:
           retention-days: 7
 
   pr-info:
-    if: ${{ github.event_name == 'pull_request_target' }}
+    if: ${{ github.event_name == 'pull_request' }}
     uses: ./.github/workflows/save-pr-info.yaml
     with:
       pr_number: ${{ github.event.number }}


### PR DESCRIPTION
Workflow was updated to start on `pull_request` event but the condition was not updated and was still looking for `pull_request_target'.