### PR TITLE
feat: log test failures by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ setup:
 
 .PHONY: test
 test:
-	npm run compatibility:test -- docker --debug --compose implementations/$(subgraph)/docker-compose.yaml --schema implementations/_template_library_/products.graphql
+	npm run compatibility:test -- docker --compose implementations/$(subgraph)/docker-compose.yaml --schema implementations/_template_library_/products.graphql
 
 .PHONY: test-all
 test-all:

--- a/packages/compatibility/src/testRunner.ts
+++ b/packages/compatibility/src/testRunner.ts
@@ -1,7 +1,7 @@
 import execa from 'execa';
 import debug from 'debug';
 import { resolve } from 'path';
-import { writeableDebugStream } from './utils/logging';
+import { infoLog, writeableDebugStream } from './utils/logging';
 
 const jestDebug = debug('test');
 
@@ -89,7 +89,7 @@ export const TESTS = [
 ];
 
 export async function runJest(productsUrl: string): Promise<JestResults> {
-  console.log(new Date().toJSON(), 'starting tests...');
+  infoLog(new Date().toJSON(), 'starting tests...');
   jestDebug(
     `\n***********************\nStarting tests...\n***********************\n\n`,
   );
@@ -111,7 +111,7 @@ export async function runJest(productsUrl: string): Promise<JestResults> {
   );
 
   proc.stdout.pipe(writeableDebugStream(jestDebug));
-  proc.stderr.pipe(writeableDebugStream(jestDebug));
+  proc.stderr.pipe(writeableDebugStream(infoLog));
 
   const { stdout, stderr } = await proc;
 

--- a/packages/compatibility/src/utils/client.ts
+++ b/packages/compatibility/src/utils/client.ts
@@ -1,4 +1,5 @@
 import fetch from 'make-fetch-happen';
+import { infoLog } from './logging';
 
 export const ROUTER_URL = 'http://localhost:4000/';
 const PING_QUERY = 'query { __typename }';
@@ -75,7 +76,7 @@ export async function healthcheckSupergraph(url: string): Promise<Boolean> {
 }
 
 export async function healthcheckRouter(): Promise<Boolean> {
-  console.log('router health check', ROUTER_HEALTH_URL);
+  infoLog('health check - router', ROUTER_HEALTH_URL);
   try {
     const routerHealthcheck = await fetch(ROUTER_HEALTH_URL, {
       retry: { retries: 10, maxTimeout: 1000 },
@@ -85,6 +86,7 @@ export async function healthcheckRouter(): Promise<Boolean> {
       console.log('router failed to start');
       return false;
     }
+    infoLog('health check - router OK');
     return true;
   } catch (err) {
     console.error('router faield to start', err);
@@ -99,13 +101,14 @@ export async function healthcheck(
   let attempts = 100;
   let lastError = null;
   while (attempts--) {
-    console.log(`${appName} health check`, url);
+    infoLog(`health check - ${appName}`, url);
     try {
       const subgraphHealthcheck = await graphqlRequest(url, {
         query: PING_QUERY,
       });
 
       if (subgraphHealthcheck.data?.__typename) {
+        infoLog(`health check - ${appName} OK`);
         return true;
       } else {
         lastError = subgraphHealthcheck.errors;

--- a/packages/compatibility/src/utils/logging.ts
+++ b/packages/compatibility/src/utils/logging.ts
@@ -1,12 +1,14 @@
-import { Debugger } from 'debug';
+import debug, { Debugger } from 'debug';
 import { Writable } from 'stream';
 import { TestResults, TESTS } from '../testRunner';
+
+export const infoLog = debug('info');
 
 /**
  * Log message with a timestamp.
  */
 export function logWithTimestamp(message: string) {
-  console.log(new Date().toJSON(), message);
+  infoLog(new Date().toJSON(), message);
 }
 
 /**

--- a/packages/script/README.md
+++ b/packages/script/README.md
@@ -77,6 +77,7 @@ Options:
   --failOnWarning                boolean flag to indicate whether any failing test should fail the script.
   --format <json|markdown>       optional output file format (choices: "json", "markdown", default: "markdown")
   -h, --help                     display help for command
+  --quiet                        suppress logging to minimum
   --schema <schema.graphql>      optional path to schema file, if omitted composition will fallback to introspection
 ```
 
@@ -128,6 +129,7 @@ Options:
   -h, --help                       display help for command
   --path <path>                    GraphQL endpoint path (default: "")
   --port <port>                    HTTP server port (default: "4001")
+  --quiet                          suppress logging to minimum
   --schema <schema.graphql>        Path to schema file
 ```
 

--- a/packages/script/src/compatibilityTestCommand.ts
+++ b/packages/script/src/compatibilityTestCommand.ts
@@ -52,6 +52,7 @@ class CompatibilityTestCommand extends Command {
           .default('markdown'),
       )
       .option('--debug', 'debug mode with extra log info')
+      .option('--quiet', 'suppress logging to minimum')
       .option(
         '--failOnRequired',
         'boolean flag to indicate whether any failing required test should fail the script.',
@@ -82,10 +83,14 @@ program
   )
   .option('--config <subgraph.config.js>', 'optional PM2 configuration file')
   .action((options) => {
-    if (options.debug) {
-      console.log('setting debug setting');
-      debug.enable('debug,pm2,docker,rover,test');
+    if (options.quiet) {
+      debug.disable();
+    } else if (options.debug) {
+      debug.enable('info,pm2,docker,rover,test');
+    } else {
+      debug.enable('info');
     }
+
     let runtimeConfig = generateRuntimeConfig(TestRuntime.PM2, options);
     compatibilityTest(runtimeConfig).then((successful) => {
       if (!successful) {
@@ -106,10 +111,14 @@ program
   .option('--path <path>', 'GraphQL endpoint path', '')
   .option('--port <port>', 'HTTP server port', '4001')
   .action((options) => {
-    if (options.debug) {
-      console.log('setting debug setting');
-      debug.enable('debug,pm2,docker,rover,test');
+    if (options.quiet) {
+      debug.disable();
+    } else if (options.debug) {
+      debug.enable('info,pm2,docker,rover,test');
+    } else {
+      debug.enable('info');
     }
+
     let runtimeConfig = generateRuntimeConfig(TestRuntime.DOCKER, options);
     compatibilityTest(runtimeConfig).then((successful) => {
       if (!successful) {


### PR DESCRIPTION
* Update default log behavior to automatically include Jest test failures in the output.
* Add new `--quiet` option to `CompatibilityTestCommand` to suppress all output except for the final compatibility results