### PR TITLE
fix absinthe test

### DIFF
--- a/implementations/absinthe-federation/Dockerfile
+++ b/implementations/absinthe-federation/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.13.4-alpine AS build
+FROM elixir:1.14.2-alpine AS build
 
 # prepare build dir
 WORKDIR /app


### PR DESCRIPTION
It appears that new Docker image was pushed that overwrote the one we were using. New image removed some utils which broke our build. Updating to newer version of Elixir to fix it.

NOTE: latest version of Elixir image v1.14.3 also has the same issue missing `crypto.so`

```
  =ERROR REPORT==== 23-Feb-2023::23:14:09.046166 ===
  Unable to load crypto library. Failed with error:
  "load_failed, Failed to load NIF library: 'Error loading shared library libcrypto.so.3: No such file or directory (needed by /app/lib/crypto-5.1.2/priv/lib/crypto.so)'"
  OpenSSL might not be installed on this system.
  docker  +1ms

  =SUPERVISOR REPORT==== 23-Feb-2023::23:14:09.046581 ===
      supervisor: {local,kernel_sup}
      errorContext: start_error
      reason: {on_load_function_failed,crypto,
                  {error,
                      {load_failed,
                          "Failed to load NIF library: 'Error loading shared library libcrypto.so.3: No such file or directory (needed by /app/lib/crypto-5.1.2/priv/lib/crypto.so)'"}}}
      offender: [{pid,undefined},
                 {id,kernel_safe_sup},
                 {mfargs,{supervisor,start_link,
  docker  +0ms
                                     [{local,kernel_safe_sup},kernel,safe]}},
                 {restart_type,permanent},
                 {significant,false},
                 {shutdown,infinity},
                 {child_type,supervisor}]
```