### PR TITLE
fix: relax field comparison logic

### DIFF
--- a/packages/compatibility/src/utils/schemaComparison.ts
+++ b/packages/compatibility/src/utils/schemaComparison.ts
@@ -79,9 +79,6 @@ function compareTypeFields(
   expectedFields: ReadonlyArray<FieldDefinitionNode>,
 ): string {
   let errors: string = '';
-  if (expectedFields.length !== fields.length) {
-    errors += `\n * ${typeName} does not declare the same number of fields`;
-  }
   expectedFields.forEach((expectedField) => {
     const matchedField = fields.find(
       (f) => f.name.value == expectedField.name.value,


### PR DESCRIPTION
Remove unnecessary check to verify the same number of fields on objects. Some implementations may auto-generate some additional fields.

Resolves: https://github.com/apollographql/apollo-federation-subgraph-compatibility/issues/388