### PR TITLE
chore: disable appsync CI workflow

### DIFF
--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -33,14 +33,14 @@ jobs:
       format: "json"
 
   # need secrets so appsync is configured separately
-  test-appsync:
-    uses: ./.github/workflows/test-subgraph.yaml
-    with:
-      library: "appsync"
-      format: "json"
-    secrets:
-      API_KEY: ${{ secrets.API_KEY_APPSYNC }}
-      TEST_URL: ${{ secrets.URL_APPSYNC }}
+  # test-appsync:
+  #   uses: ./.github/workflows/test-subgraph.yaml
+  #   with:
+  #     library: "appsync"
+  #     format: "json"
+  #   secrets:
+  #     API_KEY: ${{ secrets.API_KEY_APPSYNC }}
+  #     TEST_URL: ${{ secrets.URL_APPSYNC }}
 
   # need secrets so stepzen is configured separately
   test-stepzen:
@@ -53,7 +53,7 @@ jobs:
 
   report:
     timeout-minutes: 10
-    needs: [test, test-appsync, test-stepzen]
+    needs: [test, test-stepzen]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
AppSync test is currently broken (instance is offline), disabling it for the time being to unblock the pipeline.