### PR TITLE
fix: additional `@requires` and `@provides` tests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "ignorePaths": ["**/node_modules/**", "**/implementations/**"]
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  ignorePaths: ['**/node_modules/**', '**/implementations/**'],
 }

--- a/packages/compatibility/src/tests/provides.test.ts
+++ b/packages/compatibility/src/tests/provides.test.ts
@@ -9,7 +9,7 @@ describe('@provides', () => {
 
     const { sdl } = response.data._service;
     expect(stripIgnoredCharacters(sdl)).toMatch(
-      /createdBy:User(@provides|@federation__provides)\(fields:"totalProductsCreated"\)/
+      /createdBy:User(@provides|@federation__provides)\(fields:"totalProductsCreated"\)/,
     );
   });
 

--- a/packages/compatibility/src/tests/provides.test.ts
+++ b/packages/compatibility/src/tests/provides.test.ts
@@ -1,29 +1,43 @@
+import { stripIgnoredCharacters } from 'graphql';
 import { productsRequest } from '../utils/client';
 
-test('@provides', async () => {
-  const resp = await productsRequest({
-    query: `#graphql
+describe('@provides', () => {
+  test('should return @provides directives in _service sdl', async () => {
+    const response = await productsRequest({
+      query: 'query { _service { sdl } }',
+    });
+
+    const { sdl } = response.data._service;
+    expect(stripIgnoredCharacters(sdl)).toMatch(
+      /createdBy:User(@provides|@federation__provides)\(fields:"totalProductsCreated"\)/
+    );
+  });
+
+  test('should return locally computed @provides field', async () => {
+    const resp = await productsRequest({
+      query: `#graphql
       query ($id: ID!) {
         product(id: $id) {
           createdBy { email totalProductsCreated }
         }
       }`,
-    variables: { id: 'apollo-federation' },
-  });
+      variables: { id: 'apollo-federation' },
+    });
 
-  expect(resp).not.toHaveProperty('errors');
-  expect(resp).toMatchObject({
-    data: {
-      product: {
-        createdBy: {
-          email: 'support@apollographql.com',
-          totalProductsCreated: expect.any(Number),
+    expect(resp).not.toHaveProperty('errors');
+    expect(resp).toMatchObject({
+      data: {
+        product: {
+          createdBy: {
+            email: 'support@apollographql.com',
+            totalProductsCreated: expect.any(Number),
+          },
         },
       },
-    },
-  });
+    });
 
-  const totalProductsCreated: number =
-    resp.data.product.createdBy.totalProductsCreated;
-  expect(totalProductsCreated).not.toEqual(4);
+    const totalProductsCreated: number =
+      resp.data.product.createdBy.totalProductsCreated;
+    expect(totalProductsCreated).not.toEqual(4);
+  });
 });

--- a/packages/compatibility/src/tests/requires.test.ts
+++ b/packages/compatibility/src/tests/requires.test.ts
@@ -1,23 +1,37 @@
-import { routerRequest } from '../utils/client';
+import { stripIgnoredCharacters } from 'graphql';
+import { productsRequest, routerRequest } from '../utils/client';
 
-test('@requires', async () => {
-  const resp = await routerRequest({
-    query: `#graphql
-      query ($id: ID!) {
-        product(id: $id) { createdBy { averageProductsCreatedPerYear email } }
-      }`,
-    variables: { id: 'apollo-federation' },
+describe('@requires', () => {
+  test('should return @requires directives in _service sdl', async () => {
+    const response = await productsRequest({
+      query: 'query { _service { sdl } }',
+    });
+
+    const { sdl } = response.data._service;
+    expect(stripIgnoredCharacters(sdl)).toMatch(
+      /averageProductsCreatedPerYear:Int(@requires|@federation__requires)\(fields:"totalProductsCreated yearsOfEmployment"\)/
+    );
   });
 
-  expect(resp).not.toHaveProperty('errors');
-  expect(resp).toMatchObject({
-    data: {
-      product: {
-        createdBy: {
-          averageProductsCreatedPerYear: expect.any(Number),
-          email: 'support@apollographql.com',
+  test('should return field with computed values from @requires field set', async () => {
+    const resp = await routerRequest({
+      query: `#graphql
+        query ($id: ID!) {
+          product(id: $id) { createdBy { averageProductsCreatedPerYear email } }
+        }`,
+      variables: { id: 'apollo-federation' },
+    });
+
+    expect(resp).not.toHaveProperty('errors');
+    expect(resp).toMatchObject({
+      data: {
+        product: {
+          createdBy: {
+            averageProductsCreatedPerYear: expect.any(Number),
+            email: 'support@apollographql.com',
+          },
         },
       },
-    },
-  });
+    });
+  })
 });

--- a/packages/compatibility/src/tests/requires.test.ts
+++ b/packages/compatibility/src/tests/requires.test.ts
@@ -9,7 +9,7 @@ describe('@requires', () => {
 
     const { sdl } = response.data._service;
     expect(stripIgnoredCharacters(sdl)).toMatch(
-      /averageProductsCreatedPerYear:Int(@requires|@federation__requires)\(fields:"totalProductsCreated yearsOfEmployment"\)/
+      /averageProductsCreatedPerYear:Int(@requires|@federation__requires)\(fields:"totalProductsCreated yearsOfEmployment"\)/,
     );
   });
 
@@ -33,5 +33,5 @@ describe('@requires', () => {
         },
       },
     });
-  })
+  });
 });


### PR DESCRIPTION
Adds additional tests for `@requires` and `@provides` that whether target directives are actually applied on the schema elements.

Resolves: https://github.com/apollographql/apollo-federation-subgraph-compatibility/issues/475