### PR TITLE
build: update hosted solutions workflows

### DIFF
--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -7,7 +7,6 @@ on:
       - "Absinthe Federation Test"
       - "Apollo Server Test"
       - "Ariadne Test"
-      - "AWS AppSync Test"
       - "Ballerina GraphQL Test"
       - "Caliban Test"
       - "Dgraph Test"
@@ -24,6 +23,7 @@ on:
       - "GraphQL Mesh Test"
       - "GraphQL Yoga Test"
       - "HotChocolate Test"
+      - "Hosted Subgraph Test"
       - "Lighthouse Test"
       - "Mercurius Test"
       - "Neo4j GraphQL Library Test"
@@ -33,7 +33,6 @@ on:
       - "Pothos Test"
       - "GraphQL Ruby Test"
       - "Sangria Test"
-      - "StepZen Test"
       - "Strawberry GraphQL Test"
       - "Swift Graphiti Test"
     types:
@@ -44,7 +43,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     if: >
-      (github.event.workflow_run.event == 'pull_request' || github.event.workflow_run.event == 'pull_request_target') &&
+      (github.event.workflow_run.event == 'pull_request' || github.event.workflow_run.event == 'workflow_run') &&
       github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download Artifacts

--- a/.github/workflows/save-pr-info.yaml
+++ b/.github/workflows/save-pr-info.yaml
@@ -13,9 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Save PR number
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           mkdir -p ./pr
-          echo ${{ inputs.pr_number }} > ./pr/pr_info
+          echo $PR_NUMBER > ./pr/pr_info
       - uses: actions/upload-artifact@v3
         with:
           name: pr

--- a/.github/workflows/templates/test-subgraph-hosted.yaml.template
+++ b/.github/workflows/templates/test-subgraph-hosted.yaml.template
@@ -8,37 +8,18 @@ on:
       - 'implementations/<implementation>/**'
 
 jobs:
-  compatibility:
-    timeout-minutes: 30
+  compatibility-hosted:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Setup Environment
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'npm'
-      - name: Install dependencies and build
-        run: npm install
-      - name: Compatibility test
-        run: npm run compatibility:test -- docker --compose implementations/<implementation>/docker-compose.yaml --schema implementations/<implementation>/products.graphql
-        env:
-          # secrets are optional
-          API_KEY: ${{ secrets.API_KEY_<implementation> }}
-          TEST_URL: ${{ secrets.URL_<implementation> }}
-      - name: Generate Results Summary
+      - name: Save subgraph info
         run: |
-          cat results.md >> $GITHUB_STEP_SUMMARY
-          mv results.md results-<implementation>.md
-          echo "RESULTS_FILE=results-<implementation>.md" >> $GITHUB_ENV
-      - name: Upload Results
-        uses: actions/upload-artifact@v3
+          mkdir -p ./subgraph
+          echo <implementation> > ./subgraph/subgraph_info
+      - uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.RESULTS_FILE }}
-          path: ./${{ env.RESULTS_FILE }}
+          name: subgraph
+          path: subgraph/
           retention-days: 1
 
 

--- a/.github/workflows/test-hosted-subgraph.yaml
+++ b/.github/workflows/test-hosted-subgraph.yaml
@@ -1,0 +1,71 @@
+name: Hosted Subgraph Test
+
+on:
+  workflow_run:
+    workflows:
+      - "AWS AppSync Test"
+      - "StepZen Test"
+    types:
+      - completed
+
+jobs:
+  compatibility:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Setup Environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - name: Install dependencies and build
+        run: npm install
+      - name: Locate subgraph to test
+        uses: actions/github-script@v6
+        with:
+          script: |
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{ github.event.workflow_run.id }},
+            });
+            var subgraphArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "subgraph"
+            })[0];
+            var downloadSubgraphArtifact = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: subgraphArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/subgraph.zip', Buffer.from(downloadSubgraphArtifact.data));
+      - name: Extract subgraph information
+        run: |
+          unzip subgraph.zip
+          echo "SUBGRAPH=$(cat subgraph_info)" >> $GITHUB_ENV
+      - name: (Conditional) AppSync compatibility test
+        if: ${{ env.SUBGRAPH = 'appsync' }}
+        run: npm run compatibility:test -- docker --compose implementations/appsync/docker-compose.yaml --schema implementations/appsync/cdk/products-service/src/products-service.graphql
+        env:
+          API_KEY: ${{ secrets.API_KEY_APPSYNC }}
+          TEST_URL: ${{ secrets.URL_APPSYNC }}
+      - name: (Conditional) StepZen compatibility test
+        if: ${{ env.SUBGRAPH = 'stepzen' }}
+        run: npm run compatibility:test -- docker --compose implementations/stepzen/docker-compose.yaml --schema implementations/stepzen/products.graphql
+        env:
+          TEST_URL: ${{ secrets.URL_STEPZEN }}
+      - name: Generate Results Summary
+        run: |
+          cat results.md >> $GITHUB_STEP_SUMMARY
+          mv results.md results-${{ env.SUBGRAPH }}.md
+          echo "RESULTS_FILE=results-${{ env.SUBGRAPH }}.md" >> $GITHUB_ENV
+      - name: Upload Results
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.RESULTS_FILE }}
+          path: ./${{ env.RESULTS_FILE }}
+          retention-days: 1

--- a/.github/workflows/test-subgraph-appsync.yaml
+++ b/.github/workflows/test-subgraph-appsync.yaml
@@ -1,43 +1,25 @@
 name: AWS AppSync Test
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     paths:
       - 'implementations/appsync/**'
 
 jobs:
-  compatibility:
-    timeout-minutes: 30
+  compatibility-hosted:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Setup Environment
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'npm'
-      - name: Install dependencies and build
-        run: npm install
-      - name: Compatibility test
-        run: npm run compatibility:test -- docker --compose implementations/appsync/docker-compose.yaml --schema implementations/appsync/cdk/products-service/src/products-service.graphql
-        env:
-          API_KEY: ${{ secrets.API_KEY_APPSYNC }}
-          TEST_URL: ${{ secrets.URL_APPSYNC }}
-      - name: Generate Results Summary
+      - name: Save subgraph info
         run: |
-          cat results.md >> $GITHUB_STEP_SUMMARY
-          mv results.md results-appsync.md
-          echo "RESULTS_FILE=results-appsync.md" >> $GITHUB_ENV
-      - name: Upload Results
-        uses: actions/upload-artifact@v3
+          mkdir -p ./subgraph
+          echo appsync > ./subgraph/subgraph_info
+      - uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.RESULTS_FILE }}
-          path: ./${{ env.RESULTS_FILE }}
+          name: subgraph
+          path: subgraph/
           retention-days: 1
 
   pr-info:

--- a/.github/workflows/test-subgraph-stepzen.yaml
+++ b/.github/workflows/test-subgraph-stepzen.yaml
@@ -8,35 +8,18 @@ on:
       - 'implementations/stepzen/**'
 
 jobs:
-  compatibility:
-    timeout-minutes: 30
+  compatibility-hosted:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Setup Environment
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'npm'
-      - name: Install dependencies and build
-        run: npm install
-      - name: Compatibility test
-        run: npm run compatibility:test -- docker --compose implementations/stepzen/docker-compose.yaml --schema implementations/stepzen/products.graphql
-        env:
-          TEST_URL: ${{ secrets.URL_STEPZEN }}
-      - name: Generate Results Summary
+      - name: Save subgraph info
         run: |
-          cat results.md >> $GITHUB_STEP_SUMMARY
-          mv results.md results-stepzen.md
-          echo "RESULTS_FILE=results-stepzen.md" >> $GITHUB_ENV
-      - name: Upload Results
-        uses: actions/upload-artifact@v3
+          mkdir -p ./subgraph
+          echo stepzen > ./subgraph/subgraph_info
+      - uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.RESULTS_FILE }}
-          path: ./${{ env.RESULTS_FILE }}
+          name: subgraph
+          path: subgraph/
           retention-days: 1
 
   pr-info:

--- a/SUBGRAPH_GUIDE.md
+++ b/SUBGRAPH_GUIDE.md
@@ -85,8 +85,18 @@ compatibility tests will fail.**
    it to include the name of your implementation under `.github/workflows/test-subgraph-<hosted>.yaml`
    - This is a workflow that will be triggered for PRs opened against your implementation.
    - Modify the template so it only triggers for your implementation.
-6. Update `.github/workflows/comment.yaml` workflow to include name of your newly created workflow (
-   this will enable automatic compatibility comments on PRs against your implementation).
+6. Update `.github/workflows/test-hosted-subgraph.yaml` workflow
+   - include name of your newly created workflow to trigger compatibility tests against your PR
+   - include new conditional step to run tests against your subggraph
+
+  ```yaml
+    - name: (Conditional) <Hosted> compatibility test
+      if: ${{ env.SUBGRAPH = '<hosted>' }}
+      run: npm run compatibility:test -- docker --compose implementations/<hosted>/docker-compose.yaml --schema implementations/<hosted>/products.graphql
+      env:
+        API_KEY: ${{ secrets.API_KEY_<HOSTED> }}
+        TEST_URL: ${{ secrets.URL_<HOSTED> }}
+  ```
 7. When you are ready to integrate, reach out to us at [Apollo Community Forums](https://community.apollographql.com/).
    Send a DM to any member of the [Ecosystem Group](https://community.apollographql.com/g/Ecosystem)
    and we'll help you configure your API KEY and URL as a Github Secret. Those secrets will be used


### PR DESCRIPTION
Update workflows to no longer depend on `pull_request_target` to eliminate potential security vulnerability where unauthorized users could access the secrets.

In order to run compatibility tests against hosted solutions, we need access to the secret URL/API_KEY. Instead of relying on `pull_request_event`, workflows now trigger on regular `pull_request` event and save the subgraph information. Upon successful completion of that workflow we trigger actual test workflow (using `workflow_run` event) that downloads the subgraph information and runs the tests using elevated permissions (so it can pass down the secrets).

See: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/