### PR TITLE
Update Renovate Config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,5 +22,11 @@
     automerge: false,
     schedule: ["every weekday"],
   },
+  packageRules: [
+    {
+      matchPackageNames: ['@types/node'],
+      allowedVersions: '18.x',
+    }
+  ]
 }
 

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,10 +1,26 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   ignorePaths: ['**/node_modules/**', '**/implementations/**'],
-  packageRules: [
-    {
-      matchPackageNames: ['@types/node'],
-      allowedVersions: '18.x',
-    },
-  ],
+  // We have prCreation set to "not-pending" in the Apollo default config.
+  // However, based on the CI config in this repo, "immediate" may make more sense.
+  // See https://docs.renovatebot.com/configuration-options/#prcreation
+  // for available options.
+  prCreation: "immediate",
+  lockFileMaintenance: {
+    // This change from default in this section is adjusting
+    // the schedule attribute. In practice, setting the schedule
+    // to "weekdays" will mean that Renovate has one opportunity
+    // each weekday to create a PR to update locks.
+    // If this gets too noisy, this can be scaled back.
+    // However, with the default schedule, lockfiles update PRs 
+    // will essentially never be created because there isn't overlap
+    // between "before 4am on monday" and the times that we have 
+    // Renovate scheduled to run. 
+    // See https://docs.renovatebot.com/configuration-options/#lockfilemaintenance
+    // for details.
+    enabled: true,
+    automerge: false,
+    schedule: ["every weekday"],
+  },
 }
+


### PR DESCRIPTION
This updates the Renovate config in this repo to address some issues @dariuszkuc encountered in the last week with Renovate. Specifically, this:
1. Changes Renovate's behavior when creating PRs. Apollo's default Renovate config instructs Renovate to wait for all CI checks to complete prior to opening a PR. However, given CI only runs _on_ PRs in this repo, it creates some confusing behavior where an invisible, internal Renovate check was preventing PR creation without much feedback on why
2. Adjusts the schedule for when Renovate can open lockfile maintenance PRs. Additional commentary on this change included in the `renovate.json5` file. 