### PR TITLE
Make `--failOnRequired` and `--failOnWarning` work together.

### DIFF
--- a/packages/compatibility/src/compatibilityTest.ts
+++ b/packages/compatibility/src/compatibilityTest.ts
@@ -58,10 +58,10 @@ export async function compatibilityTest(
   // print results to console
   logResults(testResults);
 
-  if (runtimeConfig.failOnRequired) {
-    return allRequiredSuccessful;
-  } else if (runtimeConfig.failOnWarning) {
+  if (runtimeConfig.failOnWarning) {
     return allSuccessful;
+  } else if (runtimeConfig.failOnRequired) {
+    return allRequiredSuccessful;
   } else {
     return true;
   }


### PR DESCRIPTION
`--failOnWarning` is a stricter flag than `--failOnRequired` and you don't need to pass `--failOnRequired` if you pass `--failOnWarning`. However, if you did pass both, it would ignore `--failOnWarning` because it checked `--failOnWarning` first (and then returned). By checking the stricter `--failOnWarning` flag first, it works correctly whether `--failOnWarning` is passed alone or together with `--failOnRequired`.

Fixes #507.