### PR TITLE
fix: pin script version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,28 +5,27 @@
   // However, based on the CI config in this repo, "immediate" may make more sense.
   // See https://docs.renovatebot.com/configuration-options/#prcreation
   // for available options.
-  prCreation: "immediate",
+  prCreation: 'immediate',
   lockFileMaintenance: {
     // This change from default in this section is adjusting
     // the schedule attribute. In practice, setting the schedule
     // to "weekdays" will mean that Renovate has one opportunity
     // each weekday to create a PR to update locks.
     // If this gets too noisy, this can be scaled back.
-    // However, with the default schedule, lockfiles update PRs 
+    // However, with the default schedule, lockfiles update PRs
     // will essentially never be created because there isn't overlap
-    // between "before 4am on monday" and the times that we have 
-    // Renovate scheduled to run. 
+    // between "before 4am on monday" and the times that we have
+    // Renovate scheduled to run.
     // See https://docs.renovatebot.com/configuration-options/#lockfilemaintenance
     // for details.
     enabled: true,
     automerge: false,
-    schedule: ["every weekday"],
+    schedule: ['every weekday'],
   },
   packageRules: [
     {
       matchPackageNames: ['@types/node'],
       allowedVersions: '18.x',
-    }
-  ]
+    },
+  ],
 }
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1826,9 +1826,9 @@
       }
     },
     "node_modules/@pm2/io": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@pm2/io/-/io-5.0.0.tgz",
-      "integrity": "sha512-3rToDVJaRoob5Lq8+7Q2TZFruoEkdORxwzFpZaqF4bmH6Bkd7kAbdPrI/z8X6k1Meq5rTtScM7MmDgppH6aLlw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@pm2/io/-/io-5.0.2.tgz",
+      "integrity": "sha512-XAvrNoQPKOyO/jJyCu8jPhLzlyp35MEf7w/carHXmWKddPzeNOFSEpSEqMzPDawsvpxbE+i918cNN+MwgVsStA==",
       "dependencies": {
         "@opencensus/core": "0.0.9",
         "@opencensus/propagation-b3": "0.0.8",
@@ -1836,7 +1836,7 @@
         "debug": "~4.3.1",
         "eventemitter2": "^6.3.1",
         "require-in-the-middle": "^5.0.0",
-        "semver": "6.3.0",
+        "semver": "~7.5.4",
         "shimmer": "^1.2.0",
         "signal-exit": "^3.0.3",
         "tslib": "1.9.3"
@@ -1857,14 +1857,6 @@
       "version": "6.4.9",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
       "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="
-    },
-    "node_modules/@pm2/io/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
     },
     "node_modules/@pm2/io/node_modules/tslib": {
       "version": "1.9.3",
@@ -4884,9 +4876,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.0.tgz",
-      "integrity": "sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg==",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -8178,9 +8170,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.21.4",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.21.4.tgz",
-      "integrity": "sha512-fLW6j47UoAJDlZPEqykkWTKxubxb8IFuow6pMQlqf4irZ2lBgCrCReavMkH2t8VxxjOcg6wBlZ2EPQcluAT6xg==",
+      "version": "5.21.9",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.21.9.tgz",
+      "integrity": "sha512-7pI4mu9P/2MGDV0T49B52E7IULBGj+kRVk6JSYUj5qfAk7N7C7aNX15fXziqrbgZntc6/jjYzWeb/x41jhg/eA==",
       "optional": true,
       "os": [
         "darwin",
@@ -8944,7 +8936,7 @@
     },
     "packages/compatibility": {
       "name": "@apollo/federation-subgraph-compatibility-tests",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@apollo/rover": "^0.18.1",
@@ -8972,7 +8964,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@apollo/federation-subgraph-compatibility-tests": "^2.0.0",
+        "@apollo/federation-subgraph-compatibility-tests": "2.0.1",
         "commander": "^11.0.0",
         "debug": "^4.3.4"
       },
@@ -9044,7 +9036,7 @@
     "@apollo/federation-subgraph-compatibility": {
       "version": "file:packages/script",
       "requires": {
-        "@apollo/federation-subgraph-compatibility-tests": "^2.0.0",
+        "@apollo/federation-subgraph-compatibility-tests": "2.0.1",
         "@types/debug": "4.1.8",
         "commander": "^11.0.0",
         "debug": "^4.3.4"
@@ -10364,9 +10356,9 @@
       }
     },
     "@pm2/io": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@pm2/io/-/io-5.0.0.tgz",
-      "integrity": "sha512-3rToDVJaRoob5Lq8+7Q2TZFruoEkdORxwzFpZaqF4bmH6Bkd7kAbdPrI/z8X6k1Meq5rTtScM7MmDgppH6aLlw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@pm2/io/-/io-5.0.2.tgz",
+      "integrity": "sha512-XAvrNoQPKOyO/jJyCu8jPhLzlyp35MEf7w/carHXmWKddPzeNOFSEpSEqMzPDawsvpxbE+i918cNN+MwgVsStA==",
       "requires": {
         "@opencensus/core": "0.0.9",
         "@opencensus/propagation-b3": "0.0.8",
@@ -10374,7 +10366,7 @@
         "debug": "~4.3.1",
         "eventemitter2": "^6.3.1",
         "require-in-the-middle": "^5.0.0",
-        "semver": "6.3.0",
+        "semver": "~7.5.4",
         "shimmer": "^1.2.0",
         "signal-exit": "^3.0.3",
         "tslib": "1.9.3"
@@ -10392,11 +10384,6 @@
           "version": "6.4.9",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
           "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "tslib": {
           "version": "1.9.3",
@@ -12700,9 +12687,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.0.tgz",
-      "integrity": "sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg=="
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw=="
     },
     "graphql-tag": {
       "version": "2.12.6",
@@ -15098,9 +15085,9 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "systeminformation": {
-      "version": "5.21.4",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.21.4.tgz",
-      "integrity": "sha512-fLW6j47UoAJDlZPEqykkWTKxubxb8IFuow6pMQlqf4irZ2lBgCrCReavMkH2t8VxxjOcg6wBlZ2EPQcluAT6xg==",
+      "version": "5.21.9",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.21.9.tgz",
+      "integrity": "sha512-7pI4mu9P/2MGDV0T49B52E7IULBGj+kRVk6JSYUj5qfAk7N7C7aNX15fXziqrbgZntc6/jjYzWeb/x41jhg/eA==",
       "optional": true
     },
     "tar": {

--- a/packages/compatibility/package.json
+++ b/packages/compatibility/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/federation-subgraph-compatibility-tests",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Apollo Federation Subgraph Compatibility tests",
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",

--- a/packages/script/package.json
+++ b/packages/script/package.json
@@ -26,7 +26,7 @@
     "npm": ">=8.6.0"
   },
   "dependencies": {
-    "@apollo/federation-subgraph-compatibility-tests": "^2.0.0",
+    "@apollo/federation-subgraph-compatibility-tests": "2.0.1",
     "commander": "^11.0.0",
     "debug": "^4.3.4"
   },


### PR DESCRIPTION
Pin compatibility script version to exact version. Previously we were incorrectly using `^` (compatible version) when specifying versions which meant older releases always pulled in the latest minor version of the compatibility script instead of a matching version.