### PR TITLE
fix: check for fail required/warning flags in right order

### DIFF
--- a/packages/compatibility/src/compatibilityTest.ts
+++ b/packages/compatibility/src/compatibilityTest.ts
@@ -58,10 +58,10 @@ export async function compatibilityTest(
   // print results to console
   logResults(testResults);
 
-  if (runtimeConfig.failOnRequired) {
-    return allRequiredSuccessful;
-  } else if (runtimeConfig.failOnWarning) {
+  if (runtimeConfig.failOnWarning) {
     return allSuccessful;
+  } else if (runtimeConfig.failOnRequired) {
+    return allRequiredSuccessful;
   } else {
     return true;
   }


### PR DESCRIPTION
When both flags were specified, we only checked for required tests (as it was evaluated first).

Resolves: https://github.com/apollographql/apollo-federation-subgraph-compatibility/issues/507