### PR TITLE
fix: use correct casing when generating markdown

### DIFF
--- a/implementations/_template_library_/metadata.json
+++ b/implementations/_template_library_/metadata.json
@@ -13,7 +13,7 @@
     "name": "<display name of core GraphQL library - ONLY INCLUDE THIS SECTION IF DIFFERENT THAN THE MAIN LIBRARY REPO>",
     "link": "github repo | NPM link | other distribution link"
   },
-  "federationlibrary": {
+  "federationLibrary": {
     "name": "<display name of Federation library - ONLY INCLUDE THIS SECTION IF DIFFERENT THAN THE MAIN LIBRARY REPO>",
     "link": "github repo | NPM link | other distribution link"
   }

--- a/implementations/absinthe-federation/metadata.json
+++ b/implementations/absinthe-federation/metadata.json
@@ -8,7 +8,7 @@
     "owner": "absinthe-graphql",
     "link": "https://github.com/absinthe-graphql/absinthe"
   },
-  "federationlibrary": {
+  "federationLibrary": {
     "name": "absinthe_federation",
     "owner": "DivvyPayHQ",
     "link": "https://github.com/DivvyPayHQ/absinthe_federation"

--- a/implementations/apollo-server/metadata.json
+++ b/implementations/apollo-server/metadata.json
@@ -6,14 +6,14 @@
   "repository": {
     "name": "apollo-server",
     "owner": "apollographql",
-    "maintainer" : "apollographql",
+    "maintainer": "apollographql",
     "link": "https://github.com/apollographql/apollo-server"
   },
   "coreLibrary": {
     "name": "GraphQL.js",
     "link": "https://www.npmjs.com/package/graphql"
   },
-  "federationlibrary": {
+  "federationLibrary": {
     "name": "Apollo Subgraph",
     "maintainer": "apollographql",
     "link": "https://www.npmjs.com/package/@apollo/subgraph"

--- a/implementations/dgs/metadata.json
+++ b/implementations/dgs/metadata.json
@@ -12,10 +12,10 @@
     "name": "GraphQL Java",
     "link": "https://github.com/graphql-java/graphql-java"
   },
-  "federationlibrary": {
+  "federationLibrary": {
     "name": "federation-jvm",
     "owner": "apollographql",
-    "maintainer" : "apollographql",
+    "maintainer": "apollographql",
     "link": "https://github.com/apollographql/federation-jvm"
   }
 }

--- a/implementations/express-graphql/metadata.json
+++ b/implementations/express-graphql/metadata.json
@@ -12,9 +12,9 @@
     "name": "GraphQL.js",
     "link": "https://www.npmjs.com/package/graphql"
   },
-  "federationlibrary": {
+  "federationLibrary": {
     "name": "Apollo Subgraph",
-    "maintainer" : "apollographql",
+    "maintainer": "apollographql",
     "link": "https://www.npmjs.com/package/@apollo/subgraph"
   }
 }

--- a/implementations/graphene/metadata.json
+++ b/implementations/graphene/metadata.json
@@ -12,7 +12,7 @@
     "name": "GraphQL-core 3",
     "link": "https://github.com/graphql-python/graphql-core"
   },
-  "federationlibrary": {
+  "federationLibrary": {
     "name": "graphene-federation",
     "owner": "graphql-python",
     "link": "https://github.com/graphql-python/graphene-federation"

--- a/implementations/graphql-java-kickstart/metadata.json
+++ b/implementations/graphql-java-kickstart/metadata.json
@@ -12,7 +12,7 @@
     "name": "GraphQL Java",
     "link": "https://github.com/graphql-java/graphql-java"
   },
-  "federationlibrary": {
+  "federationLibrary": {
     "name": "federation-jvm",
     "owner": "apollographql",
     "maintainer": "apollographql",

--- a/implementations/graphql-yoga/metadata.json
+++ b/implementations/graphql-yoga/metadata.json
@@ -13,9 +13,9 @@
     "name": "GraphQL.js",
     "link": "https://www.npmjs.com/package/graphql"
   },
-  "federationlibrary": {
+  "federationLibrary": {
     "name": "Apollo Subgraph",
-    "maintainer" : "apollographql",
+    "maintainer": "apollographql",
     "link": "https://www.npmjs.com/package/@apollo/subgraph"
   }
 }

--- a/implementations/helix/metadata.json
+++ b/implementations/helix/metadata.json
@@ -13,9 +13,9 @@
     "name": "GraphQL.js",
     "link": "https://www.npmjs.com/package/graphql"
   },
-  "federationlibrary": {
+  "federationLibrary": {
     "name": "Apollo Subgraph",
-    "maintainer" : "apollographql",
+    "maintainer": "apollographql",
     "link": "https://www.npmjs.com/package/@apollo/subgraph"
   }
 }

--- a/implementations/hotchocolate/metadata.json
+++ b/implementations/hotchocolate/metadata.json
@@ -9,7 +9,7 @@
     "owner": "ChilliCream",
     "link": "https://github.com/ChilliCream/graphql-platform"
   },
-  "federationlibrary": {
+  "federationLibrary": {
     "name": "federation-hotchocolate",
     "owner": "apollographql",
     "maintainer": "apollographql",

--- a/implementations/mercurius/metadata.json
+++ b/implementations/mercurius/metadata.json
@@ -12,9 +12,9 @@
     "name": "GraphQL.js",
     "link": "https://www.npmjs.com/package/graphql"
   },
-  "federationlibrary": {
+  "federationLibrary": {
     "name": "Apollo Subgraph",
-    "maintainer" : "apollographql",
+    "maintainer": "apollographql",
     "link": "https://www.npmjs.com/package/@apollo/subgraph"
   }
 }

--- a/implementations/neo4j-graphql/metadata.json
+++ b/implementations/neo4j-graphql/metadata.json
@@ -12,9 +12,9 @@
         "name": "GraphQL.js",
         "link": "https://www.npmjs.com/package/graphql"
     },
-    "federationlibrary": {
+    "federationLibrary": {
         "name": "Apollo Subgraph",
-        "maintainer" : "apollographql",
+        "maintainer": "apollographql",
         "link": "https://www.npmjs.com/package/@apollo/subgraph"
     }
 }

--- a/implementations/nestjs-code-first/metadata.json
+++ b/implementations/nestjs-code-first/metadata.json
@@ -13,9 +13,9 @@
     "name": "GraphQL.js",
     "link": "https://www.npmjs.com/package/graphql"
   },
-  "federationlibrary": {
+  "federationLibrary": {
     "name": "Apollo Subgraph",
-    "maintainer" : "apollographql",
+    "maintainer": "apollographql",
     "link": "https://www.npmjs.com/package/@apollo/subgraph"
   }
 }

--- a/implementations/nestjs/metadata.json
+++ b/implementations/nestjs/metadata.json
@@ -13,9 +13,9 @@
     "name": "GraphQL.js",
     "link": "https://www.npmjs.com/package/graphql"
   },
-  "federationlibrary": {
+  "federationLibrary": {
     "name": "Apollo Subgraph",
-    "maintainer" : "apollographql",
+    "maintainer": "apollographql",
     "link": "https://www.npmjs.com/package/@apollo/subgraph"
   }
 }

--- a/implementations/php/metadata.json
+++ b/implementations/php/metadata.json
@@ -8,7 +8,7 @@
     "owner": "webonyx",
     "link": "https://github.com/webonyx/graphql-php"
   },
-  "federationlibrary": {
+  "federationLibrary": {
     "name": "apollo-federation-php",
     "owner": "Skillshare",
     "link": "https://github.com/Skillshare/apollo-federation-php"

--- a/implementations/ruby/metadata.json
+++ b/implementations/ruby/metadata.json
@@ -8,7 +8,7 @@
     "owner": "rmosolgo",
     "link": "https://github.com/rmosolgo/graphql-ruby"
   },
-  "federationlibrary": {
+  "federationLibrary": {
     "name": "Gusto/apollo-federation-ruby",
     "link": "https://github.com/Gusto/apollo-federation-ruby/"
   }

--- a/implementations/sangria/metadata.json
+++ b/implementations/sangria/metadata.json
@@ -8,7 +8,7 @@
     "owner": "sangria-graphql",
     "link": "https://github.com/sangria-graphql/sangria"
   },
-  "federationlibrary": {
+  "federationLibrary": {
     "name": "sangria-federated",
     "owner": "sangria-graphql",
     "link": "https://github.com/sangria-graphql/sangria-federated"

--- a/implementations/spring-graphql/metadata.json
+++ b/implementations/spring-graphql/metadata.json
@@ -12,7 +12,7 @@
     "name": "GraphQL Java",
     "link": "https://github.com/graphql-java/graphql-java"
   },
-  "federationlibrary": {
+  "federationLibrary": {
     "name": "federation-jvm",
     "owner": "apollographql",
     "maintainer": "apollographql",

--- a/packages/compatibility/src/testRunner.ts
+++ b/packages/compatibility/src/testRunner.ts
@@ -154,7 +154,7 @@ export interface TestResultDetails {
   }[];
   repository?: RepositoryInformation;
   coreLibrary?: RepositoryInformation;
-  federationlibrary?: RepositoryInformation;
+  federationLibrary?: RepositoryInformation;
   started: boolean;
   tests: TestResults;
 }

--- a/packages/compatibility/src/utils/markdown.ts
+++ b/packages/compatibility/src/utils/markdown.ts
@@ -46,9 +46,9 @@ Github: <a href="{{{link}}}">{{{name}}}{{#apolloIcon}}&nbsp;&nbsp;{{{apolloIcon}
 {{#coreLibrary}}
 Core Library: <a href="{{{link}}}">{{{name}}}{{#apolloIcon}}&nbsp;&nbsp;{{{apolloIcon}}}{{/apolloIcon}}</a><br/>
 {{/coreLibrary}}
-{{#federationlibrary}}
+{{#federationLibrary}}
 Federation Library: <a href="{{{link}}}">{{{name}}}{{#apolloIcon}}&nbsp;&nbsp;{{{apolloIcon}}}{{/apolloIcon}}</a>
-{{/federationlibrary}}
+{{/federationLibrary}}
       </td>
       {{#compatibilities}}
       <td>
@@ -199,15 +199,15 @@ export function generateMarkdown(results: TestResultDetails[]) {
       };
     }
 
-    if (result.federationlibrary) {
-      let fedLibraryName = result.federationlibrary.owner
-        ? `${result.federationlibrary.owner}/${result.federationlibrary.name}`
-        : result.federationlibrary.name;
+    if (result.federationLibrary) {
+      let fedLibraryName = result.federationLibrary.owner
+        ? `${result.federationLibrary.owner}/${result.federationLibrary.name}`
+        : result.federationLibrary.name;
       impl.federationLibrary = {
         name: fedLibraryName,
-        link: result.federationlibrary.link,
+        link: result.federationLibrary.link,
         apolloIcon:
-          apolloName == result.federationlibrary.maintainer ? apolloIcon : null,
+          apolloName == result.federationLibrary.maintainer ? apolloIcon : null,
       };
     }
     current.implementations.push(impl);


### PR DESCRIPTION
Update to use everywhere `federationLibrary` instead of `federationlibrary`.