### PR TITLE
fix: pin ruby to 3.2

### DIFF
--- a/implementations/ruby/Dockerfile
+++ b/implementations/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:latest
+FROM ruby:3.2
 WORKDIR /web
 COPY ./Gemfile* /web/
 RUN bundle


### PR DESCRIPTION
There is an issue with Ruby 3.3 that prevents subgraph from starting. We'll fix it later.