### PR TITLE
chore: disable AppSync tests

### DIFF
--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -33,14 +33,14 @@ jobs:
       format: "json"
 
   # need secrets so appsync is configured separately
-  test-appsync:
-    uses: ./.github/workflows/test-subgraph.yaml
-    with:
-      library: "appsync"
-      format: "json"
-    secrets:
-      API_KEY: ${{ secrets.API_KEY_APPSYNC }}
-      TEST_URL: ${{ secrets.URL_APPSYNC }}
+  # test-appsync:
+  #   uses: ./.github/workflows/test-subgraph.yaml
+  #   with:
+  #     library: "appsync"
+  #     format: "json"
+  #   secrets:
+  #     API_KEY: ${{ secrets.API_KEY_APPSYNC }}
+  #     TEST_URL: ${{ secrets.URL_APPSYNC }}
 
   # need secrets so stepzen is configured separately
   test-stepzen:

--- a/.github/workflows/test-hosted-subgraph.yaml
+++ b/.github/workflows/test-hosted-subgraph.yaml
@@ -3,7 +3,7 @@ name: Hosted Subgraph Test
 on:
   workflow_run:
     workflows:
-      - "AWS AppSync Test"
+      # - "AWS AppSync Test"
       - "StepZen Test"
     types:
       - completed


### PR DESCRIPTION
Looks like keys might have expired as tests can no longer start up/connect to the subgraph.