### PR TITLE
Update package version to 2.2.2

### DIFF
--- a/packages/compatibility/package.json
+++ b/packages/compatibility/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/federation-subgraph-compatibility-tests",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Apollo Federation Subgraph Compatibility tests",
   "author": "Apollo <packages@apollographql.com>",
   "license": "MIT",

--- a/packages/script/package.json
+++ b/packages/script/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/federation-subgraph-compatibility",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A CLI tool for checking a subgraph's compatibility with a federated gateway",
   "bin": {
     "fedtest": "./dist/compatibilityTestCommand.js"
@@ -26,7 +26,7 @@
     "npm": ">=8.6.0"
   },
   "dependencies": {
-    "@apollo/federation-subgraph-compatibility-tests": "2.2.1",
+    "@apollo/federation-subgraph-compatibility-tests": "2.2.2",
     "commander": "^11.0.0",
     "debug": "^4.3.4"
   },


### PR DESCRIPTION
This is a follow-up to [PR#682](https://github.com/apollographql/apollo-federation-subgraph-compatibility/pull/682), where an update was made to `package.json` but the semantic version of the package was not updated accordingly.